### PR TITLE
content: 1.2.24

### DIFF
--- a/app_data/sheets/template/articles.json
+++ b/app_data/sheets/template/articles.json
@@ -6,10 +6,22 @@
     {
       "name": "answer_list",
       "value": [
-        "name: all | image: images/icons/globe_blue.svg",
-        "name: education | image: images/icons/school_blue.svg",
-        "name: child_dev | image: images/icons/leaf_blue.svg",
-        "name: relations | image: images/icons/heart_blue.svg"
+        {
+          "name": "all",
+          "image": "images/icons/globe_blue.svg"
+        },
+        {
+          "name": "education",
+          "image": "images/icons/school_blue.svg"
+        },
+        {
+          "name": "child_dev",
+          "image": "images/icons/leaf_blue.svg"
+        },
+        {
+          "name": "relations",
+          "image": "images/icons/heart_blue.svg"
+        }
       ],
       "type": "set_variable",
       "_nested_name": "answer_list"
@@ -181,7 +193,7 @@
                 "value": {}
               },
               "type": "set_variable",
-              "_nested_name": "items.box_@item.id.id",
+              "_nested_name": "items_7.box_@item.id.id",
               "_dynamicFields": {
                 "value": [
                   {
@@ -193,7 +205,7 @@
                 ],
                 "_nested_name": [
                   {
-                    "fullExpression": "items.box_@item.id.id",
+                    "fullExpression": "items_7.box_@item.id.id",
                     "matchedExpression": "@item.id.id",
                     "type": "item",
                     "fieldName": "id"
@@ -210,7 +222,7 @@
               }
             }
           ],
-          "_nested_name": "items.box_@item.id",
+          "_nested_name": "items_7.box_@item.id",
           "_dynamicFields": {
             "name": [
               {
@@ -242,7 +254,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "items.box_@item.id",
+                "fullExpression": "items_7.box_@item.id",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -264,8 +276,8 @@
           }
         }
       ],
-      "name": "items",
-      "_nested_name": "items",
+      "name": "items_7",
+      "_nested_name": "items_7",
       "_dynamicFields": {
         "value": [
           {

--- a/app_data/sheets/template/assets_demo.json
+++ b/app_data/sheets/template/assets_demo.json
@@ -9,8 +9,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "title",
-      "_nested_name": "title"
+      "name": "title_2",
+      "_nested_name": "title_2"
     },
     {
       "type": "image",
@@ -18,8 +18,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "image",
-      "_nested_name": "image"
+      "name": "image_3",
+      "_nested_name": "image_3"
     },
     {
       "type": "image",
@@ -27,8 +27,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "image",
-      "_nested_name": "image"
+      "name": "image_4",
+      "_nested_name": "image_4"
     }
   ],
   "_xlsxPath": "doc_sheets/assets_demo.xlsx"

--- a/app_data/sheets/template/comp_odk_form.json
+++ b/app_data/sheets/template/comp_odk_form.json
@@ -81,8 +81,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "subtitle",
-      "_nested_name": "subtitle"
+      "name": "subtitle_6",
+      "_nested_name": "subtitle_6"
     },
     {
       "type": "odk_form",

--- a/app_data/sheets/template/component_demo/comp_accordion.json
+++ b/app_data/sheets/template/component_demo/comp_accordion.json
@@ -93,7 +93,7 @@
               "parameter_list": {
                 "width": "150px"
               },
-              "_nested_name": "items.@item.id.{@item.id}_name",
+              "_nested_name": "items_5.@item.id.{@item.id}_name",
               "_dynamicFields": {
                 "name": [
                   {
@@ -113,13 +113,13 @@
                 ],
                 "_nested_name": [
                   {
-                    "fullExpression": "items.@item.id.{@item.id}_name",
+                    "fullExpression": "items_5.@item.id.{@item.id}_name",
                     "matchedExpression": "@item.id",
                     "type": "item",
                     "fieldName": "id"
                   },
                   {
-                    "fullExpression": "items.@item.id.{@item.id}_name",
+                    "fullExpression": "items_5.@item.id.{@item.id}_name",
                     "matchedExpression": "@item.id",
                     "type": "item",
                     "fieldName": "id"
@@ -146,7 +146,7 @@
               "parameter_list": {
                 "width": "100px"
               },
-              "_nested_name": "items.@item.id.{@item.id}_input",
+              "_nested_name": "items_5.@item.id.{@item.id}_input",
               "_dynamicFields": {
                 "name": [
                   {
@@ -174,13 +174,13 @@
                 ],
                 "_nested_name": [
                   {
-                    "fullExpression": "items.@item.id.{@item.id}_input",
+                    "fullExpression": "items_5.@item.id.{@item.id}_input",
                     "matchedExpression": "@item.id",
                     "type": "item",
                     "fieldName": "id"
                   },
                   {
-                    "fullExpression": "items.@item.id.{@item.id}_input",
+                    "fullExpression": "items_5.@item.id.{@item.id}_input",
                     "matchedExpression": "@item.id",
                     "type": "item",
                     "fieldName": "id"
@@ -214,7 +214,7 @@
               "parameter_list": {
                 "width": "100px"
               },
-              "_nested_name": "items.@item.id.{@item.id}_input",
+              "_nested_name": "items_5.@item.id.{@item.id}_input",
               "_dynamicFields": {
                 "name": [
                   {
@@ -254,13 +254,13 @@
                 },
                 "_nested_name": [
                   {
-                    "fullExpression": "items.@item.id.{@item.id}_input",
+                    "fullExpression": "items_5.@item.id.{@item.id}_input",
                     "matchedExpression": "@item.id",
                     "type": "item",
                     "fieldName": "id"
                   },
                   {
-                    "fullExpression": "items.@item.id.{@item.id}_input",
+                    "fullExpression": "items_5.@item.id.{@item.id}_input",
                     "matchedExpression": "@item.id",
                     "type": "item",
                     "fieldName": "id"
@@ -290,7 +290,7 @@
               "parameter_list": {
                 "flex": "1"
               },
-              "_nested_name": "items.@item.id.{@item.id}_description",
+              "_nested_name": "items_5.@item.id.{@item.id}_description",
               "_dynamicFields": {
                 "name": [
                   {
@@ -310,13 +310,13 @@
                 ],
                 "_nested_name": [
                   {
-                    "fullExpression": "items.@item.id.{@item.id}_description",
+                    "fullExpression": "items_5.@item.id.{@item.id}_description",
                     "matchedExpression": "@item.id",
                     "type": "item",
                     "fieldName": "id"
                   },
                   {
-                    "fullExpression": "items.@item.id.{@item.id}_description",
+                    "fullExpression": "items_5.@item.id.{@item.id}_description",
                     "matchedExpression": "@item.id",
                     "type": "item",
                     "fieldName": "id"
@@ -335,7 +335,7 @@
               }
             }
           ],
-          "_nested_name": "items.@item.id",
+          "_nested_name": "items_5.@item.id",
           "_dynamicFields": {
             "name": [
               {
@@ -347,7 +347,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "items.@item.id",
+                "fullExpression": "items_5.@item.id",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -362,8 +362,8 @@
           }
         }
       ],
-      "name": "items",
-      "_nested_name": "items",
+      "name": "items_5",
+      "_nested_name": "items_5",
       "_dynamicFields": {
         "value": [
           {

--- a/app_data/sheets/template/component_demo/comp_audio.json
+++ b/app_data/sheets/template/component_demo/comp_audio.json
@@ -10,8 +10,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "title",
-      "_nested_name": "title"
+      "name": "title_2",
+      "_nested_name": "title_2"
     },
     {
       "type": "audio",
@@ -34,8 +34,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "title",
-      "_nested_name": "title"
+      "name": "title_4",
+      "_nested_name": "title_4"
     },
     {
       "type": "audio",

--- a/app_data/sheets/template/component_demo/comp_button.json
+++ b/app_data/sheets/template/component_demo/comp_button.json
@@ -42,8 +42,8 @@
       "parameter_list": {
         "style": "card"
       },
-      "name": "button",
-      "_nested_name": "button"
+      "name": "button_4",
+      "_nested_name": "button_4"
     },
     {
       "type": "button",
@@ -55,8 +55,8 @@
         "style": "card",
         "icon": "images/icons/leaf_blue.svg"
       },
-      "name": "button",
-      "_nested_name": "button"
+      "name": "button_5",
+      "_nested_name": "button_5"
     },
     {
       "type": "button",
@@ -73,11 +73,11 @@
             "position": "right",
             "style": "in_button"
           },
-          "_nested_name": "button.toggle_bar_1"
+          "_nested_name": "button_6.toggle_bar_1"
         }
       ],
-      "name": "button",
-      "_nested_name": "button"
+      "name": "button_6",
+      "_nested_name": "button_6"
     },
     {
       "type": "title",
@@ -85,8 +85,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "title",
-      "_nested_name": "title"
+      "name": "title_8",
+      "_nested_name": "title_8"
     },
     {
       "type": "button",
@@ -99,11 +99,11 @@
         {
           "type": "toggle_bar",
           "name": "toggle_bar_2",
-          "_nested_name": "button.toggle_bar_2"
+          "_nested_name": "button_9.toggle_bar_2"
         }
       ],
-      "name": "button",
-      "_nested_name": "button"
+      "name": "button_9",
+      "_nested_name": "button_9"
     },
     {
       "type": "button",
@@ -148,7 +148,7 @@
             "icon_true_asset": "images/icons/heart_blue.svg",
             "icon_false_asset": "images/icons/heart_outline.svg"
           },
-          "_nested_name": "button.toggle_bar_3",
+          "_nested_name": "button_11.toggle_bar_3",
           "_dynamicFields": {
             "value": [
               {
@@ -190,8 +190,8 @@
           }
         }
       ],
-      "name": "button",
-      "_nested_name": "button"
+      "name": "button_11",
+      "_nested_name": "button_11"
     },
     {
       "type": "title",

--- a/app_data/sheets/template/component_demo/comp_calendar.json
+++ b/app_data/sheets/template/component_demo/comp_calendar.json
@@ -10,13 +10,13 @@
       "_translations": {
         "value": {}
       },
-      "name": "title",
-      "_nested_name": "title"
+      "name": "title_2",
+      "_nested_name": "title_2"
     },
     {
       "type": "calendar",
-      "name": "calendar",
-      "_nested_name": "calendar"
+      "name": "calendar_3",
+      "_nested_name": "calendar_3"
     }
   ],
   "_xlsxPath": "component_sheets/component_calendar.xlsx"

--- a/app_data/sheets/template/component_demo/comp_carousel.json
+++ b/app_data/sheets/template/component_demo/comp_carousel.json
@@ -10,8 +10,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "title",
-      "_nested_name": "title"
+      "name": "title_2",
+      "_nested_name": "title_2"
     },
     {
       "type": "text",
@@ -19,8 +19,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "text",
-      "_nested_name": "text"
+      "name": "text_3",
+      "_nested_name": "text_3"
     },
     {
       "type": "carousel",
@@ -45,8 +45,8 @@
               "_translations": {
                 "value": {}
               },
-              "name": "title",
-              "_nested_name": "carousel.slide_1.title"
+              "name": "title_1",
+              "_nested_name": "carousel_4.slide_1.title_1"
             },
             {
               "type": "text",
@@ -54,11 +54,11 @@
               "_translations": {
                 "value": {}
               },
-              "name": "text",
-              "_nested_name": "carousel.slide_1.text"
+              "name": "text_2",
+              "_nested_name": "carousel_4.slide_1.text_2"
             }
           ],
-          "_nested_name": "carousel.slide_1"
+          "_nested_name": "carousel_4.slide_1"
         },
         {
           "type": "display_group",
@@ -76,8 +76,8 @@
               "_translations": {
                 "value": {}
               },
-              "name": "title",
-              "_nested_name": "carousel.slide_2.title"
+              "name": "title_1",
+              "_nested_name": "carousel_4.slide_2.title_1"
             },
             {
               "type": "text",
@@ -85,11 +85,11 @@
               "_translations": {
                 "value": {}
               },
-              "name": "text",
-              "_nested_name": "carousel.slide_2.text"
+              "name": "text_2",
+              "_nested_name": "carousel_4.slide_2.text_2"
             }
           ],
-          "_nested_name": "carousel.slide_2"
+          "_nested_name": "carousel_4.slide_2"
         },
         {
           "type": "display_group",
@@ -107,8 +107,8 @@
               "_translations": {
                 "value": {}
               },
-              "name": "title",
-              "_nested_name": "carousel.slide_3.title"
+              "name": "title_1",
+              "_nested_name": "carousel_4.slide_3.title_1"
             },
             {
               "type": "text",
@@ -116,11 +116,11 @@
               "_translations": {
                 "value": {}
               },
-              "name": "text",
-              "_nested_name": "carousel.slide_3.text"
+              "name": "text_2",
+              "_nested_name": "carousel_4.slide_3.text_2"
             }
           ],
-          "_nested_name": "carousel.slide_3"
+          "_nested_name": "carousel_4.slide_3"
         },
         {
           "type": "display_group",
@@ -138,8 +138,8 @@
               "_translations": {
                 "value": {}
               },
-              "name": "title",
-              "_nested_name": "carousel.slide_4.title"
+              "name": "title_1",
+              "_nested_name": "carousel_4.slide_4.title_1"
             },
             {
               "type": "text",
@@ -147,11 +147,11 @@
               "_translations": {
                 "value": {}
               },
-              "name": "text",
-              "_nested_name": "carousel.slide_4.text"
+              "name": "text_2",
+              "_nested_name": "carousel_4.slide_4.text_2"
             }
           ],
-          "_nested_name": "carousel.slide_4"
+          "_nested_name": "carousel_4.slide_4"
         },
         {
           "type": "display_group",
@@ -169,8 +169,8 @@
               "_translations": {
                 "value": {}
               },
-              "name": "title",
-              "_nested_name": "carousel.slide_5.title"
+              "name": "title_1",
+              "_nested_name": "carousel_4.slide_5.title_1"
             },
             {
               "type": "text",
@@ -178,15 +178,15 @@
               "_translations": {
                 "value": {}
               },
-              "name": "text",
-              "_nested_name": "carousel.slide_5.text"
+              "name": "text_2",
+              "_nested_name": "carousel_4.slide_5.text_2"
             }
           ],
-          "_nested_name": "carousel.slide_5"
+          "_nested_name": "carousel_4.slide_5"
         }
       ],
-      "name": "carousel",
-      "_nested_name": "carousel"
+      "name": "carousel_4",
+      "_nested_name": "carousel_4"
     },
     {
       "type": "text",
@@ -194,8 +194,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "text",
-      "_nested_name": "text"
+      "name": "text_6",
+      "_nested_name": "text_6"
     },
     {
       "type": "carousel",
@@ -220,8 +220,8 @@
               "_translations": {
                 "value": {}
               },
-              "name": "title",
-              "_nested_name": "carousel.slide_1.title"
+              "name": "title_1",
+              "_nested_name": "carousel_7.slide_1.title_1"
             },
             {
               "type": "text",
@@ -229,11 +229,11 @@
               "_translations": {
                 "value": {}
               },
-              "name": "text",
-              "_nested_name": "carousel.slide_1.text"
+              "name": "text_2",
+              "_nested_name": "carousel_7.slide_1.text_2"
             }
           ],
-          "_nested_name": "carousel.slide_1"
+          "_nested_name": "carousel_7.slide_1"
         },
         {
           "type": "display_group",
@@ -251,8 +251,8 @@
               "_translations": {
                 "value": {}
               },
-              "name": "title",
-              "_nested_name": "carousel.slide_2.title"
+              "name": "title_1",
+              "_nested_name": "carousel_7.slide_2.title_1"
             },
             {
               "type": "text",
@@ -260,11 +260,11 @@
               "_translations": {
                 "value": {}
               },
-              "name": "text",
-              "_nested_name": "carousel.slide_2.text"
+              "name": "text_2",
+              "_nested_name": "carousel_7.slide_2.text_2"
             }
           ],
-          "_nested_name": "carousel.slide_2"
+          "_nested_name": "carousel_7.slide_2"
         },
         {
           "type": "display_group",
@@ -282,8 +282,8 @@
               "_translations": {
                 "value": {}
               },
-              "name": "title",
-              "_nested_name": "carousel.slide_3.title"
+              "name": "title_1",
+              "_nested_name": "carousel_7.slide_3.title_1"
             },
             {
               "type": "text",
@@ -291,11 +291,11 @@
               "_translations": {
                 "value": {}
               },
-              "name": "text",
-              "_nested_name": "carousel.slide_3.text"
+              "name": "text_2",
+              "_nested_name": "carousel_7.slide_3.text_2"
             }
           ],
-          "_nested_name": "carousel.slide_3"
+          "_nested_name": "carousel_7.slide_3"
         },
         {
           "type": "display_group",
@@ -313,8 +313,8 @@
               "_translations": {
                 "value": {}
               },
-              "name": "title",
-              "_nested_name": "carousel.slide_4.title"
+              "name": "title_1",
+              "_nested_name": "carousel_7.slide_4.title_1"
             },
             {
               "type": "text",
@@ -322,11 +322,11 @@
               "_translations": {
                 "value": {}
               },
-              "name": "text",
-              "_nested_name": "carousel.slide_4.text"
+              "name": "text_2",
+              "_nested_name": "carousel_7.slide_4.text_2"
             }
           ],
-          "_nested_name": "carousel.slide_4"
+          "_nested_name": "carousel_7.slide_4"
         },
         {
           "type": "display_group",
@@ -344,8 +344,8 @@
               "_translations": {
                 "value": {}
               },
-              "name": "title",
-              "_nested_name": "carousel.slide_5.title"
+              "name": "title_1",
+              "_nested_name": "carousel_7.slide_5.title_1"
             },
             {
               "type": "text",
@@ -353,15 +353,15 @@
               "_translations": {
                 "value": {}
               },
-              "name": "text",
-              "_nested_name": "carousel.slide_5.text"
+              "name": "text_2",
+              "_nested_name": "carousel_7.slide_5.text_2"
             }
           ],
-          "_nested_name": "carousel.slide_5"
+          "_nested_name": "carousel_7.slide_5"
         }
       ],
-      "name": "carousel",
-      "_nested_name": "carousel"
+      "name": "carousel_7",
+      "_nested_name": "carousel_7"
     },
     {
       "type": "text",
@@ -369,8 +369,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "text",
-      "_nested_name": "text"
+      "name": "text_9",
+      "_nested_name": "text_9"
     },
     {
       "type": "carousel",
@@ -394,8 +394,8 @@
               "_translations": {
                 "value": {}
               },
-              "name": "title",
-              "_nested_name": "carousel.slide_1.title"
+              "name": "title_1",
+              "_nested_name": "carousel_10.slide_1.title_1"
             },
             {
               "type": "text",
@@ -403,11 +403,11 @@
               "_translations": {
                 "value": {}
               },
-              "name": "text",
-              "_nested_name": "carousel.slide_1.text"
+              "name": "text_2",
+              "_nested_name": "carousel_10.slide_1.text_2"
             }
           ],
-          "_nested_name": "carousel.slide_1"
+          "_nested_name": "carousel_10.slide_1"
         },
         {
           "type": "display_group",
@@ -425,8 +425,8 @@
               "_translations": {
                 "value": {}
               },
-              "name": "title",
-              "_nested_name": "carousel.slide_2.title"
+              "name": "title_1",
+              "_nested_name": "carousel_10.slide_2.title_1"
             },
             {
               "type": "text",
@@ -434,11 +434,11 @@
               "_translations": {
                 "value": {}
               },
-              "name": "text",
-              "_nested_name": "carousel.slide_2.text"
+              "name": "text_2",
+              "_nested_name": "carousel_10.slide_2.text_2"
             }
           ],
-          "_nested_name": "carousel.slide_2"
+          "_nested_name": "carousel_10.slide_2"
         },
         {
           "type": "display_group",
@@ -456,8 +456,8 @@
               "_translations": {
                 "value": {}
               },
-              "name": "title",
-              "_nested_name": "carousel.slide_3.title"
+              "name": "title_1",
+              "_nested_name": "carousel_10.slide_3.title_1"
             },
             {
               "type": "text",
@@ -465,11 +465,11 @@
               "_translations": {
                 "value": {}
               },
-              "name": "text",
-              "_nested_name": "carousel.slide_3.text"
+              "name": "text_2",
+              "_nested_name": "carousel_10.slide_3.text_2"
             }
           ],
-          "_nested_name": "carousel.slide_3"
+          "_nested_name": "carousel_10.slide_3"
         },
         {
           "type": "display_group",
@@ -487,8 +487,8 @@
               "_translations": {
                 "value": {}
               },
-              "name": "title",
-              "_nested_name": "carousel.slide_4.title"
+              "name": "title_1",
+              "_nested_name": "carousel_10.slide_4.title_1"
             },
             {
               "type": "text",
@@ -496,11 +496,11 @@
               "_translations": {
                 "value": {}
               },
-              "name": "text",
-              "_nested_name": "carousel.slide_4.text"
+              "name": "text_2",
+              "_nested_name": "carousel_10.slide_4.text_2"
             }
           ],
-          "_nested_name": "carousel.slide_4"
+          "_nested_name": "carousel_10.slide_4"
         },
         {
           "type": "display_group",
@@ -518,8 +518,8 @@
               "_translations": {
                 "value": {}
               },
-              "name": "title",
-              "_nested_name": "carousel.slide_5.title"
+              "name": "title_1",
+              "_nested_name": "carousel_10.slide_5.title_1"
             },
             {
               "type": "text",
@@ -527,15 +527,15 @@
               "_translations": {
                 "value": {}
               },
-              "name": "text",
-              "_nested_name": "carousel.slide_5.text"
+              "name": "text_2",
+              "_nested_name": "carousel_10.slide_5.text_2"
             }
           ],
-          "_nested_name": "carousel.slide_5"
+          "_nested_name": "carousel_10.slide_5"
         }
       ],
-      "name": "carousel",
-      "_nested_name": "carousel"
+      "name": "carousel_10",
+      "_nested_name": "carousel_10"
     },
     {
       "type": "text",
@@ -543,8 +543,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "text",
-      "_nested_name": "text"
+      "name": "text_12",
+      "_nested_name": "text_12"
     },
     {
       "type": "carousel",
@@ -568,8 +568,8 @@
               "_translations": {
                 "value": {}
               },
-              "name": "title",
-              "_nested_name": "carousel.slide_1.title"
+              "name": "title_1",
+              "_nested_name": "carousel_13.slide_1.title_1"
             },
             {
               "type": "text",
@@ -577,11 +577,11 @@
               "_translations": {
                 "value": {}
               },
-              "name": "text",
-              "_nested_name": "carousel.slide_1.text"
+              "name": "text_2",
+              "_nested_name": "carousel_13.slide_1.text_2"
             }
           ],
-          "_nested_name": "carousel.slide_1"
+          "_nested_name": "carousel_13.slide_1"
         },
         {
           "type": "display_group",
@@ -599,8 +599,8 @@
               "_translations": {
                 "value": {}
               },
-              "name": "title",
-              "_nested_name": "carousel.slide_2.title"
+              "name": "title_1",
+              "_nested_name": "carousel_13.slide_2.title_1"
             },
             {
               "type": "text",
@@ -608,11 +608,11 @@
               "_translations": {
                 "value": {}
               },
-              "name": "text",
-              "_nested_name": "carousel.slide_2.text"
+              "name": "text_2",
+              "_nested_name": "carousel_13.slide_2.text_2"
             }
           ],
-          "_nested_name": "carousel.slide_2"
+          "_nested_name": "carousel_13.slide_2"
         },
         {
           "type": "display_group",
@@ -630,8 +630,8 @@
               "_translations": {
                 "value": {}
               },
-              "name": "title",
-              "_nested_name": "carousel.slide_3.title"
+              "name": "title_1",
+              "_nested_name": "carousel_13.slide_3.title_1"
             },
             {
               "type": "text",
@@ -639,11 +639,11 @@
               "_translations": {
                 "value": {}
               },
-              "name": "text",
-              "_nested_name": "carousel.slide_3.text"
+              "name": "text_2",
+              "_nested_name": "carousel_13.slide_3.text_2"
             }
           ],
-          "_nested_name": "carousel.slide_3"
+          "_nested_name": "carousel_13.slide_3"
         },
         {
           "type": "display_group",
@@ -661,8 +661,8 @@
               "_translations": {
                 "value": {}
               },
-              "name": "title",
-              "_nested_name": "carousel.slide_4.title"
+              "name": "title_1",
+              "_nested_name": "carousel_13.slide_4.title_1"
             },
             {
               "type": "text",
@@ -670,11 +670,11 @@
               "_translations": {
                 "value": {}
               },
-              "name": "text",
-              "_nested_name": "carousel.slide_4.text"
+              "name": "text_2",
+              "_nested_name": "carousel_13.slide_4.text_2"
             }
           ],
-          "_nested_name": "carousel.slide_4"
+          "_nested_name": "carousel_13.slide_4"
         },
         {
           "type": "display_group",
@@ -692,8 +692,8 @@
               "_translations": {
                 "value": {}
               },
-              "name": "title",
-              "_nested_name": "carousel.slide_5.title"
+              "name": "title_1",
+              "_nested_name": "carousel_13.slide_5.title_1"
             },
             {
               "type": "text",
@@ -701,15 +701,15 @@
               "_translations": {
                 "value": {}
               },
-              "name": "text",
-              "_nested_name": "carousel.slide_5.text"
+              "name": "text_2",
+              "_nested_name": "carousel_13.slide_5.text_2"
             }
           ],
-          "_nested_name": "carousel.slide_5"
+          "_nested_name": "carousel_13.slide_5"
         }
       ],
-      "name": "carousel",
-      "_nested_name": "carousel"
+      "name": "carousel_13",
+      "_nested_name": "carousel_13"
     },
     {
       "type": "title",
@@ -717,8 +717,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "title",
-      "_nested_name": "title"
+      "name": "title_15",
+      "_nested_name": "title_15"
     },
     {
       "type": "text",
@@ -726,8 +726,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "text",
-      "_nested_name": "text"
+      "name": "text_16",
+      "_nested_name": "text_16"
     },
     {
       "type": "carousel",
@@ -742,7 +742,7 @@
             "value": {}
           },
           "type": "set_variable",
-          "_nested_name": "carousel.task_group_id"
+          "_nested_name": "carousel_17.task_group_id"
         },
         {
           "name": "task_id",
@@ -751,7 +751,7 @@
             "value": {}
           },
           "type": "set_variable",
-          "_nested_name": "carousel.task_id"
+          "_nested_name": "carousel_17.task_id"
         },
         {
           "name": "stepper",
@@ -760,7 +760,7 @@
             "value": {}
           },
           "type": "set_variable",
-          "_nested_name": "carousel.stepper"
+          "_nested_name": "carousel_17.stepper"
         },
         {
           "name": "completed",
@@ -769,7 +769,7 @@
             "value": {}
           },
           "type": "set_variable",
-          "_nested_name": "carousel.completed"
+          "_nested_name": "carousel_17.completed"
         },
         {
           "name": "join",
@@ -778,7 +778,7 @@
             "value": {}
           },
           "type": "set_variable",
-          "_nested_name": "carousel.join"
+          "_nested_name": "carousel_17.join"
         },
         {
           "name": "card_title",
@@ -787,7 +787,7 @@
             "value": {}
           },
           "type": "set_variable",
-          "_nested_name": "carousel.card_title"
+          "_nested_name": "carousel_17.card_title"
         },
         {
           "name": "card_subtitle",
@@ -796,7 +796,7 @@
             "value": {}
           },
           "type": "set_variable",
-          "_nested_name": "carousel.card_subtitle"
+          "_nested_name": "carousel_17.card_subtitle"
         },
         {
           "name": "card_image",
@@ -805,7 +805,7 @@
             "value": {}
           },
           "type": "set_variable",
-          "_nested_name": "carousel.card_image"
+          "_nested_name": "carousel_17.card_image"
         },
         {
           "type": "task_card",
@@ -839,7 +839,7 @@
             "in_progress_icon": "plh_images/icons/in_progress.svg",
             "completed_icon": "plh_images/icons/tick_white.svg"
           },
-          "_nested_name": "carousel.task_card_1",
+          "_nested_name": "carousel_17.task_card_1",
           "_dynamicFields": {
             "action_list": {
               "0": {
@@ -979,7 +979,7 @@
             "in_progress_icon": "plh_images/icons/in_progress.svg",
             "completed_icon": "plh_images/icons/tick_white.svg"
           },
-          "_nested_name": "carousel.task_card_2",
+          "_nested_name": "carousel_17.task_card_2",
           "_dynamicFields": {
             "action_list": {
               "0": {
@@ -1119,7 +1119,7 @@
             "in_progress_icon": "plh_images/icons/in_progress.svg",
             "completed_icon": "plh_images/icons/tick_white.svg"
           },
-          "_nested_name": "carousel.task_card_3",
+          "_nested_name": "carousel_17.task_card_3",
           "_dynamicFields": {
             "action_list": {
               "0": {
@@ -1259,7 +1259,7 @@
             "in_progress_icon": "plh_images/icons/in_progress.svg",
             "completed_icon": "plh_images/icons/tick_white.svg"
           },
-          "_nested_name": "carousel.task_card_4",
+          "_nested_name": "carousel_17.task_card_4",
           "_dynamicFields": {
             "action_list": {
               "0": {
@@ -1399,7 +1399,7 @@
             "in_progress_icon": "plh_images/icons/in_progress.svg",
             "completed_icon": "plh_images/icons/tick_white.svg"
           },
-          "_nested_name": "carousel.task_card_5",
+          "_nested_name": "carousel_17.task_card_5",
           "_dynamicFields": {
             "action_list": {
               "0": {
@@ -1508,8 +1508,8 @@
           }
         }
       ],
-      "name": "carousel",
-      "_nested_name": "carousel"
+      "name": "carousel_17",
+      "_nested_name": "carousel_17"
     }
   ],
   "_xlsxPath": "component_sheets/component_carousel.xlsx"

--- a/app_data/sheets/template/component_demo/comp_combo_box.json
+++ b/app_data/sheets/template/component_demo/comp_combo_box.json
@@ -24,9 +24,18 @@
     {
       "name": "answer_list_1",
       "value": [
-        "name: name_1 | text: This is text 1",
-        "name: name_2 | text: This is text 2",
-        "name: name_3 | text: This is text 3"
+        {
+          "name": "name_1",
+          "text": "This is text 1"
+        },
+        {
+          "name": "name_2",
+          "text": "This is text 2"
+        },
+        {
+          "name": "name_3",
+          "text": "This is text 3"
+        }
       ],
       "type": "set_variable",
       "_nested_name": "answer_list_1"

--- a/app_data/sheets/template/component_demo/comp_dashed_box.json
+++ b/app_data/sheets/template/component_demo/comp_dashed_box.json
@@ -97,8 +97,8 @@
         "style": "alert"
       },
       "type": "set_variable",
-      "name": "set_variable",
-      "_nested_name": "set_variable"
+      "name": "set_variable_13",
+      "_nested_name": "set_variable_13"
     }
   ],
   "_xlsxPath": "component_sheets/component_dashed_box.xlsx"

--- a/app_data/sheets/template/component_demo/comp_data_items.json
+++ b/app_data/sheets/template/component_demo/comp_data_items.json
@@ -33,7 +33,7 @@
           "_translations": {
             "value": {}
           },
-          "_nested_name": "data_items.id_@item.id",
+          "_nested_name": "data_items_4.id_@item.id",
           "_dynamicFields": {
             "name": [
               {
@@ -53,7 +53,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "data_items.id_@item.id",
+                "fullExpression": "data_items_4.id_@item.id",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -75,7 +75,7 @@
           "_translations": {
             "value": {}
           },
-          "_nested_name": "data_items.text_completed_@item.id",
+          "_nested_name": "data_items_4.text_completed_@item.id",
           "_dynamicFields": {
             "name": [
               {
@@ -95,7 +95,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "data_items.text_completed_@item.id",
+                "fullExpression": "data_items_4.text_completed_@item.id",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -131,7 +131,7 @@
               }
             }
           ],
-          "_nested_name": "data_items.toggle_button_@item.id",
+          "_nested_name": "data_items_4.toggle_button_@item.id",
           "_dynamicFields": {
             "name": [
               {
@@ -173,7 +173,7 @@
             },
             "_nested_name": [
               {
-                "fullExpression": "data_items.toggle_button_@item.id",
+                "fullExpression": "data_items_4.toggle_button_@item.id",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -193,8 +193,8 @@
           }
         }
       ],
-      "name": "data_items",
-      "_nested_name": "data_items",
+      "name": "data_items_4",
+      "_nested_name": "data_items_4",
       "_dynamicFields": {
         "value": [
           {
@@ -234,7 +234,7 @@
           "_translations": {
             "value": {}
           },
-          "_nested_name": "data_items.id_@item.id",
+          "_nested_name": "data_items_7.id_@item.id",
           "_dynamicFields": {
             "name": [
               {
@@ -254,7 +254,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "data_items.id_@item.id",
+                "fullExpression": "data_items_7.id_@item.id",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -276,7 +276,7 @@
           "_translations": {
             "value": {}
           },
-          "_nested_name": "data_items.text_completed_@item.id",
+          "_nested_name": "data_items_7.text_completed_@item.id",
           "_dynamicFields": {
             "name": [
               {
@@ -296,7 +296,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "data_items.text_completed_@item.id",
+                "fullExpression": "data_items_7.text_completed_@item.id",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -314,8 +314,8 @@
           }
         }
       ],
-      "name": "data_items",
-      "_nested_name": "data_items",
+      "name": "data_items_7",
+      "_nested_name": "data_items_7",
       "_dynamicFields": {
         "parameter_list": {
           "filter": [
@@ -351,9 +351,10 @@
     {
       "type": "button",
       "name": "data_list_set",
-      "value": [
-        "Set data list"
-      ],
+      "value": "Set data list",
+      "_translations": {
+        "value": {}
+      },
       "action_list": [
         {
           "trigger": "click",
@@ -387,9 +388,10 @@
     {
       "type": "button",
       "name": "data_list_unset",
-      "value": [
-        "Unset data list"
-      ],
+      "value": "Unset data list",
+      "_translations": {
+        "value": {}
+      },
       "action_list": [
         {
           "trigger": "click",
@@ -434,7 +436,7 @@
           "_translations": {
             "value": {}
           },
-          "_nested_name": "data_items.id_@item.id",
+          "_nested_name": "data_items_13.id_@item.id",
           "_dynamicFields": {
             "name": [
               {
@@ -454,7 +456,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "data_items.id_@item.id",
+                "fullExpression": "data_items_13.id_@item.id",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -476,7 +478,7 @@
           "_translations": {
             "value": {}
           },
-          "_nested_name": "data_items.text_completed_@item.id",
+          "_nested_name": "data_items_13.text_completed_@item.id",
           "_dynamicFields": {
             "name": [
               {
@@ -496,7 +498,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "data_items.text_completed_@item.id",
+                "fullExpression": "data_items_13.text_completed_@item.id",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -514,8 +516,8 @@
           }
         }
       ],
-      "name": "data_items",
-      "_nested_name": "data_items",
+      "name": "data_items_13",
+      "_nested_name": "data_items_13",
       "_dynamicFields": {
         "value": [
           {
@@ -580,7 +582,7 @@
               }
             }
           ],
-          "_nested_name": "data_items.mark_uncompleted_button"
+          "_nested_name": "data_items_16.mark_uncompleted_button"
         },
         {
           "type": "button",
@@ -601,7 +603,7 @@
               }
             }
           ],
-          "_nested_name": "data_items.toggle_all_button",
+          "_nested_name": "data_items_16.toggle_all_button",
           "_dynamicFields": {
             "action_list": {
               "0": {
@@ -643,8 +645,8 @@
           }
         }
       ],
-      "name": "data_items",
-      "_nested_name": "data_items",
+      "name": "data_items_16",
+      "_nested_name": "data_items_16",
       "_dynamicFields": {
         "value": [
           {
@@ -681,7 +683,7 @@
           "_translations": {
             "value": {}
           },
-          "_nested_name": "data_items.id_@item.id",
+          "_nested_name": "data_items_19.id_@item.id",
           "_dynamicFields": {
             "name": [
               {
@@ -701,7 +703,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "data_items.id_@item.id",
+                "fullExpression": "data_items_19.id_@item.id",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -723,7 +725,7 @@
           "_translations": {
             "value": {}
           },
-          "_nested_name": "data_items.index_@item._index",
+          "_nested_name": "data_items_19.index_@item._index",
           "_dynamicFields": {
             "name": [
               {
@@ -743,7 +745,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "data_items.index_@item._index",
+                "fullExpression": "data_items_19.index_@item._index",
                 "matchedExpression": "@item._index",
                 "type": "item",
                 "fieldName": "_index"
@@ -765,7 +767,7 @@
           "_translations": {
             "value": {}
           },
-          "_nested_name": "data_items.text_completed_@item.id",
+          "_nested_name": "data_items_19.text_completed_@item.id",
           "_dynamicFields": {
             "name": [
               {
@@ -785,7 +787,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "data_items.text_completed_@item.id",
+                "fullExpression": "data_items_19.text_completed_@item.id",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -821,7 +823,7 @@
               }
             }
           ],
-          "_nested_name": "data_items.this_button_@item.id",
+          "_nested_name": "data_items_19.this_button_@item.id",
           "_dynamicFields": {
             "name": [
               {
@@ -833,7 +835,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "data_items.this_button_@item.id",
+                "fullExpression": "data_items_19.this_button_@item.id",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -866,7 +868,7 @@
               }
             }
           ],
-          "_nested_name": "data_items.this_button_@item.id",
+          "_nested_name": "data_items_19.this_button_@item.id",
           "_dynamicFields": {
             "name": [
               {
@@ -878,7 +880,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "data_items.this_button_@item.id",
+                "fullExpression": "data_items_19.this_button_@item.id",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -912,7 +914,7 @@
               }
             }
           ],
-          "_nested_name": "data_items.index_1_button_@item.id",
+          "_nested_name": "data_items_19.index_1_button_@item.id",
           "_dynamicFields": {
             "name": [
               {
@@ -924,7 +926,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "data_items.index_1_button_@item.id",
+                "fullExpression": "data_items_19.index_1_button_@item.id",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -958,7 +960,7 @@
               }
             }
           ],
-          "_nested_name": "data_items.id_button_@item.id",
+          "_nested_name": "data_items_19.id_button_@item.id",
           "_dynamicFields": {
             "name": [
               {
@@ -970,7 +972,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "data_items.id_button_@item.id",
+                "fullExpression": "data_items_19.id_button_@item.id",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -1004,7 +1006,7 @@
               }
             }
           ],
-          "_nested_name": "data_items.index_plus_1_button_@item.id",
+          "_nested_name": "data_items_19.index_plus_1_button_@item.id",
           "_dynamicFields": {
             "name": [
               {
@@ -1046,7 +1048,7 @@
             },
             "_nested_name": [
               {
-                "fullExpression": "data_items.index_plus_1_button_@item.id",
+                "fullExpression": "data_items_19.index_plus_1_button_@item.id",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -1066,8 +1068,8 @@
           }
         }
       ],
-      "name": "data_items",
-      "_nested_name": "data_items",
+      "name": "data_items_19",
+      "_nested_name": "data_items_19",
       "_dynamicFields": {
         "value": [
           {
@@ -1099,8 +1101,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "title",
-      "_nested_name": "title"
+      "name": "title_22",
+      "_nested_name": "title_22"
     },
     {
       "type": "data_items",
@@ -1118,8 +1120,8 @@
               "_translations": {
                 "value": {}
               },
-              "name": "text",
-              "_nested_name": "data_items.display_group.text",
+              "name": "text_1",
+              "_nested_name": "data_items_23.display_group_1.text_1",
               "_dynamicFields": {
                 "value": [
                   {
@@ -1142,8 +1144,8 @@
               "_translations": {
                 "value": {}
               },
-              "name": "text",
-              "_nested_name": "data_items.display_group.text",
+              "name": "text_2",
+              "_nested_name": "data_items_23.display_group_1.text_2",
               "_dynamicFields": {
                 "value": [
                   {
@@ -1166,8 +1168,8 @@
               "_translations": {
                 "value": {}
               },
-              "name": "text",
-              "_nested_name": "data_items.display_group.text",
+              "name": "text_3",
+              "_nested_name": "data_items_23.display_group_1.text_3",
               "_dynamicFields": {
                 "value": [
                   {
@@ -1190,8 +1192,8 @@
               "_translations": {
                 "value": {}
               },
-              "name": "text",
-              "_nested_name": "data_items.display_group.text",
+              "name": "text_4",
+              "_nested_name": "data_items_23.display_group_1.text_4",
               "_dynamicFields": {
                 "value": [
                   {
@@ -1214,8 +1216,8 @@
               "_translations": {
                 "value": {}
               },
-              "name": "text",
-              "_nested_name": "data_items.display_group.text",
+              "name": "text_5",
+              "_nested_name": "data_items_23.display_group_1.text_5",
               "_dynamicFields": {
                 "value": [
                   {
@@ -1233,8 +1235,8 @@
               }
             }
           ],
-          "name": "display_group",
-          "_nested_name": "data_items.display_group"
+          "name": "display_group_1",
+          "_nested_name": "data_items_23.display_group_1"
         },
         {
           "type": "button",
@@ -1254,8 +1256,8 @@
               }
             }
           ],
-          "name": "button",
-          "_nested_name": "data_items.button",
+          "name": "button_2",
+          "_nested_name": "data_items_23.button_2",
           "_dynamicFields": {
             "action_list": {
               "0": {
@@ -1297,8 +1299,8 @@
           }
         }
       ],
-      "name": "data_items",
-      "_nested_name": "data_items",
+      "name": "data_items_23",
+      "_nested_name": "data_items_23",
       "_dynamicFields": {
         "value": [
           {
@@ -1334,8 +1336,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "title",
-      "_nested_name": "title"
+      "name": "title_25",
+      "_nested_name": "title_25"
     },
     {
       "type": "data_items",
@@ -1353,8 +1355,8 @@
               "_translations": {
                 "value": {}
               },
-              "name": "text",
-              "_nested_name": "data_items.display_group.text",
+              "name": "text_1",
+              "_nested_name": "data_items_26.display_group_1.text_1",
               "_dynamicFields": {
                 "value": [
                   {
@@ -1377,8 +1379,8 @@
               "_translations": {
                 "value": {}
               },
-              "name": "text",
-              "_nested_name": "data_items.display_group.text",
+              "name": "text_2",
+              "_nested_name": "data_items_26.display_group_1.text_2",
               "_dynamicFields": {
                 "value": [
                   {
@@ -1401,8 +1403,8 @@
               "_translations": {
                 "value": {}
               },
-              "name": "text",
-              "_nested_name": "data_items.display_group.text",
+              "name": "text_3",
+              "_nested_name": "data_items_26.display_group_1.text_3",
               "_dynamicFields": {
                 "value": [
                   {
@@ -1425,8 +1427,8 @@
               "_translations": {
                 "value": {}
               },
-              "name": "text",
-              "_nested_name": "data_items.display_group.text",
+              "name": "text_4",
+              "_nested_name": "data_items_26.display_group_1.text_4",
               "_dynamicFields": {
                 "value": [
                   {
@@ -1449,8 +1451,8 @@
               "_translations": {
                 "value": {}
               },
-              "name": "text",
-              "_nested_name": "data_items.display_group.text",
+              "name": "text_5",
+              "_nested_name": "data_items_26.display_group_1.text_5",
               "_dynamicFields": {
                 "value": [
                   {
@@ -1468,8 +1470,8 @@
               }
             }
           ],
-          "name": "display_group",
-          "_nested_name": "data_items.display_group"
+          "name": "display_group_1",
+          "_nested_name": "data_items_26.display_group_1"
         },
         {
           "type": "button",
@@ -1489,8 +1491,8 @@
               }
             }
           ],
-          "name": "button",
-          "_nested_name": "data_items.button",
+          "name": "button_2",
+          "_nested_name": "data_items_26.button_2",
           "_dynamicFields": {
             "action_list": {
               "0": {
@@ -1532,8 +1534,8 @@
           }
         }
       ],
-      "name": "data_items",
-      "_nested_name": "data_items",
+      "name": "data_items_26",
+      "_nested_name": "data_items_26",
       "_dynamicFields": {
         "value": [
           {

--- a/app_data/sheets/template/component_demo/comp_display_grid.json
+++ b/app_data/sheets/template/component_demo/comp_display_grid.json
@@ -42,7 +42,7 @@
               "style_list": [
                 "width: 150px"
               ],
-              "_nested_name": "items.@item.id.{@item.id}_name",
+              "_nested_name": "items_4.@item.id.{@item.id}_name",
               "_dynamicFields": {
                 "name": [
                   {
@@ -62,13 +62,13 @@
                 ],
                 "_nested_name": [
                   {
-                    "fullExpression": "items.@item.id.{@item.id}_name",
+                    "fullExpression": "items_4.@item.id.{@item.id}_name",
                     "matchedExpression": "@item.id",
                     "type": "item",
                     "fieldName": "id"
                   },
                   {
-                    "fullExpression": "items.@item.id.{@item.id}_name",
+                    "fullExpression": "items_4.@item.id.{@item.id}_name",
                     "matchedExpression": "@item.id",
                     "type": "item",
                     "fieldName": "id"
@@ -107,7 +107,7 @@
                 }
               ],
               "exclude_from_translation": true,
-              "_nested_name": "items.@item.id.{@item.id}_input",
+              "_nested_name": "items_4.@item.id.{@item.id}_input",
               "_dynamicFields": {
                 "type": [
                   {
@@ -143,13 +143,13 @@
                 ],
                 "_nested_name": [
                   {
-                    "fullExpression": "items.@item.id.{@item.id}_input",
+                    "fullExpression": "items_4.@item.id.{@item.id}_input",
                     "matchedExpression": "@item.id",
                     "type": "item",
                     "fieldName": "id"
                   },
                   {
-                    "fullExpression": "items.@item.id.{@item.id}_input",
+                    "fullExpression": "items_4.@item.id.{@item.id}_input",
                     "matchedExpression": "@item.id",
                     "type": "item",
                     "fieldName": "id"
@@ -178,7 +178,7 @@
               "style_list": [
                 "width: 100px"
               ],
-              "_nested_name": "items.@item.id.{@item.id}_input",
+              "_nested_name": "items_4.@item.id.{@item.id}_input",
               "_dynamicFields": {
                 "name": [
                   {
@@ -198,13 +198,13 @@
                 ],
                 "_nested_name": [
                   {
-                    "fullExpression": "items.@item.id.{@item.id}_input",
+                    "fullExpression": "items_4.@item.id.{@item.id}_input",
                     "matchedExpression": "@item.id",
                     "type": "item",
                     "fieldName": "id"
                   },
                   {
-                    "fullExpression": "items.@item.id.{@item.id}_input",
+                    "fullExpression": "items_4.@item.id.{@item.id}_input",
                     "matchedExpression": "@item.id",
                     "type": "item",
                     "fieldName": "id"
@@ -232,7 +232,7 @@
               "style_list": [
                 "flex: 1"
               ],
-              "_nested_name": "items.@item.id.{@item.id}_description",
+              "_nested_name": "items_4.@item.id.{@item.id}_description",
               "_dynamicFields": {
                 "name": [
                   {
@@ -252,13 +252,13 @@
                 ],
                 "_nested_name": [
                   {
-                    "fullExpression": "items.@item.id.{@item.id}_description",
+                    "fullExpression": "items_4.@item.id.{@item.id}_description",
                     "matchedExpression": "@item.id",
                     "type": "item",
                     "fieldName": "id"
                   },
                   {
-                    "fullExpression": "items.@item.id.{@item.id}_description",
+                    "fullExpression": "items_4.@item.id.{@item.id}_description",
                     "matchedExpression": "@item.id",
                     "type": "item",
                     "fieldName": "id"
@@ -277,7 +277,7 @@
               }
             }
           ],
-          "_nested_name": "items.@item.id",
+          "_nested_name": "items_4.@item.id",
           "_dynamicFields": {
             "name": [
               {
@@ -289,7 +289,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "items.@item.id",
+                "fullExpression": "items_4.@item.id",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -304,8 +304,8 @@
           }
         }
       ],
-      "name": "items",
-      "_nested_name": "items",
+      "name": "items_4",
+      "_nested_name": "items_4",
       "_dynamicFields": {
         "value": [
           {
@@ -359,7 +359,7 @@
                   "_translations": {
                     "value": {}
                   },
-                  "_nested_name": "grid_1.items.display_group.{@item.id}_id",
+                  "_nested_name": "grid_1.items_1.display_group_1.{@item.id}_id",
                   "_dynamicFields": {
                     "name": [
                       {
@@ -379,7 +379,7 @@
                     ],
                     "_nested_name": [
                       {
-                        "fullExpression": "grid_1.items.display_group.{@item.id}_id",
+                        "fullExpression": "grid_1.items_1.display_group_1.{@item.id}_id",
                         "matchedExpression": "@item.id",
                         "type": "item",
                         "fieldName": "id"
@@ -401,7 +401,7 @@
                   "_translations": {
                     "value": {}
                   },
-                  "_nested_name": "grid_1.items.display_group.{@item.id}_text",
+                  "_nested_name": "grid_1.items_1.display_group_1.{@item.id}_text",
                   "_dynamicFields": {
                     "name": [
                       {
@@ -421,7 +421,7 @@
                     ],
                     "_nested_name": [
                       {
-                        "fullExpression": "grid_1.items.display_group.{@item.id}_text",
+                        "fullExpression": "grid_1.items_1.display_group_1.{@item.id}_text",
                         "matchedExpression": "@item.id",
                         "type": "item",
                         "fieldName": "id"
@@ -439,12 +439,12 @@
                   }
                 }
               ],
-              "name": "display_group",
-              "_nested_name": "grid_1.items.display_group"
+              "name": "display_group_1",
+              "_nested_name": "grid_1.items_1.display_group_1"
             }
           ],
-          "name": "items",
-          "_nested_name": "grid_1.items",
+          "name": "items_1",
+          "_nested_name": "grid_1.items_1",
           "_dynamicFields": {
             "value": [
               {
@@ -545,7 +545,7 @@
               "_translations": {
                 "value": {}
               },
-              "_nested_name": "grid_2.items.{@item.id}_image",
+              "_nested_name": "grid_2.items_1.{@item.id}_image",
               "_dynamicFields": {
                 "name": [
                   {
@@ -565,7 +565,7 @@
                 ],
                 "_nested_name": [
                   {
-                    "fullExpression": "grid_2.items.{@item.id}_image",
+                    "fullExpression": "grid_2.items_1.{@item.id}_image",
                     "matchedExpression": "@item.id",
                     "type": "item",
                     "fieldName": "id"
@@ -583,8 +583,8 @@
               }
             }
           ],
-          "name": "items",
-          "_nested_name": "grid_2.items",
+          "name": "items_1",
+          "_nested_name": "grid_2.items_1",
           "_dynamicFields": {
             "value": [
               {

--- a/app_data/sheets/template/component_demo/comp_drawer.json
+++ b/app_data/sheets/template/component_demo/comp_drawer.json
@@ -10,8 +10,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "title",
-      "_nested_name": "title"
+      "name": "title_2",
+      "_nested_name": "title_2"
     },
     {
       "type": "text",
@@ -19,8 +19,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "text",
-      "_nested_name": "text"
+      "name": "text_3",
+      "_nested_name": "text_3"
     },
     {
       "type": "text",
@@ -28,8 +28,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "text",
-      "_nested_name": "text"
+      "name": "text_4",
+      "_nested_name": "text_4"
     },
     {
       "type": "text",
@@ -37,8 +37,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "text",
-      "_nested_name": "text"
+      "name": "text_5",
+      "_nested_name": "text_5"
     },
     {
       "type": "text",
@@ -46,8 +46,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "text",
-      "_nested_name": "text"
+      "name": "text_6",
+      "_nested_name": "text_6"
     },
     {
       "type": "text",
@@ -55,8 +55,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "text",
-      "_nested_name": "text"
+      "name": "text_7",
+      "_nested_name": "text_7"
     },
     {
       "type": "text",
@@ -64,8 +64,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "text",
-      "_nested_name": "text"
+      "name": "text_8",
+      "_nested_name": "text_8"
     },
     {
       "type": "text",
@@ -73,8 +73,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "text",
-      "_nested_name": "text"
+      "name": "text_9",
+      "_nested_name": "text_9"
     },
     {
       "type": "text",
@@ -82,8 +82,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "text",
-      "_nested_name": "text"
+      "name": "text_10",
+      "_nested_name": "text_10"
     },
     {
       "type": "drawer",
@@ -104,8 +104,8 @@
               "_translations": {
                 "value": {}
               },
-              "name": "button",
-              "_nested_name": "drawer.display_group.button"
+              "name": "button_1",
+              "_nested_name": "drawer_11.display_group_1.button_1"
             },
             {
               "type": "button",
@@ -113,16 +113,16 @@
               "_translations": {
                 "value": {}
               },
-              "name": "button",
-              "_nested_name": "drawer.display_group.button"
+              "name": "button_2",
+              "_nested_name": "drawer_11.display_group_1.button_2"
             }
           ],
-          "name": "display_group",
-          "_nested_name": "drawer.display_group"
+          "name": "display_group_1",
+          "_nested_name": "drawer_11.display_group_1"
         }
       ],
-      "name": "drawer",
-      "_nested_name": "drawer"
+      "name": "drawer_11",
+      "_nested_name": "drawer_11"
     }
   ],
   "_xlsxPath": "component_sheets/component_drawer.xlsx"

--- a/app_data/sheets/template/component_demo/comp_navigation_bar.json
+++ b/app_data/sheets/template/component_demo/comp_navigation_bar.json
@@ -7,49 +7,70 @@
     {
       "name": "button_list",
       "value": [
-        "name: home_screen_button | text: @global.home_screen | image: plh_images/icons/house_white.svg | target_template: home_screen",
-        "name: parent_points_button | text: @global.parent_points | image: plh_images/icons/parent_child_white.svg | target_template: parent_points",
-        "name: parent_library_button | text: @global.parent_centre | image: plh_images/icons/book_white.svg | target_template: parent_centre"
+        {
+          "name": "home_screen_button",
+          "text": "@global.home_screen",
+          "image": "plh_images/icons/house_white.svg",
+          "target_template": "home_screen"
+        },
+        {
+          "name": "parent_points_button",
+          "text": "@global.parent_points",
+          "image": "plh_images/icons/parent_child_white.svg",
+          "target_template": "parent_points"
+        },
+        {
+          "name": "parent_library_button",
+          "text": "@global.parent_centre",
+          "image": "plh_images/icons/book_white.svg",
+          "target_template": "parent_centre"
+        }
       ],
       "type": "set_variable",
       "_nested_name": "button_list",
       "_dynamicFields": {
         "value": {
-          "0": [
-            {
-              "fullExpression": "name: home_screen_button | text: @global.home_screen | image: plh_images/icons/house_white.svg | target_template: home_screen",
-              "matchedExpression": "@global.home_screen",
-              "type": "global",
-              "fieldName": "home_screen"
-            }
-          ],
-          "1": [
-            {
-              "fullExpression": "name: parent_points_button | text: @global.parent_points | image: plh_images/icons/parent_child_white.svg | target_template: parent_points",
-              "matchedExpression": "@global.parent_points",
-              "type": "global",
-              "fieldName": "parent_points"
-            }
-          ],
-          "2": [
-            {
-              "fullExpression": "name: parent_library_button | text: @global.parent_centre | image: plh_images/icons/book_white.svg | target_template: parent_centre",
-              "matchedExpression": "@global.parent_centre",
-              "type": "global",
-              "fieldName": "parent_centre"
-            }
-          ]
+          "0": {
+            "text": [
+              {
+                "fullExpression": "@global.home_screen",
+                "matchedExpression": "@global.home_screen",
+                "type": "global",
+                "fieldName": "home_screen"
+              }
+            ]
+          },
+          "1": {
+            "text": [
+              {
+                "fullExpression": "@global.parent_points",
+                "matchedExpression": "@global.parent_points",
+                "type": "global",
+                "fieldName": "parent_points"
+              }
+            ]
+          },
+          "2": {
+            "text": [
+              {
+                "fullExpression": "@global.parent_centre",
+                "matchedExpression": "@global.parent_centre",
+                "type": "global",
+                "fieldName": "parent_centre"
+              }
+            ]
+          }
         }
       },
       "_dynamicDependencies": {
         "@global.home_screen": [
-          "value.0"
+          "value.0.text"
         ],
         "@global.parent_points": [
-          "value.1"
+          "value.1.text"
         ],
         "@global.parent_centre": [
-          "value.2"
+          "value.2.text"
         ]
       }
     },
@@ -58,8 +79,8 @@
       "parameter_list": {
         "button_list": "@local.button_list"
       },
-      "name": "navigation_bar",
-      "_nested_name": "navigation_bar",
+      "name": "navigation_bar_3",
+      "_nested_name": "navigation_bar_3",
       "_dynamicFields": {
         "parameter_list": {
           "button_list": [

--- a/app_data/sheets/template/component_demo/comp_qr_code.json
+++ b/app_data/sheets/template/component_demo/comp_qr_code.json
@@ -19,8 +19,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "title",
-      "_nested_name": "title"
+      "name": "title_3",
+      "_nested_name": "title_3"
     },
     {
       "type": "text",
@@ -28,8 +28,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "text",
-      "_nested_name": "text",
+      "name": "text_4",
+      "_nested_name": "text_4",
       "_dynamicFields": {
         "value": [
           {
@@ -52,8 +52,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "title",
-      "_nested_name": "title"
+      "name": "title_5",
+      "_nested_name": "title_5"
     },
     {
       "type": "qr_code",
@@ -61,8 +61,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "qr_code",
-      "_nested_name": "qr_code",
+      "name": "qr_code_6",
+      "_nested_name": "qr_code_6",
       "_dynamicFields": {
         "value": [
           {

--- a/app_data/sheets/template/component_demo/comp_radio_button_grid.json
+++ b/app_data/sheets/template/component_demo/comp_radio_button_grid.json
@@ -42,7 +42,7 @@
               "style_list": [
                 "width: 150px"
               ],
-              "_nested_name": "items.@item.id.{@item.id}_name",
+              "_nested_name": "items_4.@item.id.{@item.id}_name",
               "_dynamicFields": {
                 "name": [
                   {
@@ -62,13 +62,13 @@
                 ],
                 "_nested_name": [
                   {
-                    "fullExpression": "items.@item.id.{@item.id}_name",
+                    "fullExpression": "items_4.@item.id.{@item.id}_name",
                     "matchedExpression": "@item.id",
                     "type": "item",
                     "fieldName": "id"
                   },
                   {
-                    "fullExpression": "items.@item.id.{@item.id}_name",
+                    "fullExpression": "items_4.@item.id.{@item.id}_name",
                     "matchedExpression": "@item.id",
                     "type": "item",
                     "fieldName": "id"
@@ -107,7 +107,7 @@
                 }
               ],
               "exclude_from_translation": true,
-              "_nested_name": "items.@item.id.{@item.id}_input",
+              "_nested_name": "items_4.@item.id.{@item.id}_input",
               "_dynamicFields": {
                 "name": [
                   {
@@ -135,13 +135,13 @@
                 ],
                 "_nested_name": [
                   {
-                    "fullExpression": "items.@item.id.{@item.id}_input",
+                    "fullExpression": "items_4.@item.id.{@item.id}_input",
                     "matchedExpression": "@item.id",
                     "type": "item",
                     "fieldName": "id"
                   },
                   {
-                    "fullExpression": "items.@item.id.{@item.id}_input",
+                    "fullExpression": "items_4.@item.id.{@item.id}_input",
                     "matchedExpression": "@item.id",
                     "type": "item",
                     "fieldName": "id"
@@ -167,7 +167,7 @@
               "style_list": [
                 "width: 100px"
               ],
-              "_nested_name": "items.@item.id.{@item.id}_input",
+              "_nested_name": "items_4.@item.id.{@item.id}_input",
               "_dynamicFields": {
                 "name": [
                   {
@@ -187,13 +187,13 @@
                 ],
                 "_nested_name": [
                   {
-                    "fullExpression": "items.@item.id.{@item.id}_input",
+                    "fullExpression": "items_4.@item.id.{@item.id}_input",
                     "matchedExpression": "@item.id",
                     "type": "item",
                     "fieldName": "id"
                   },
                   {
-                    "fullExpression": "items.@item.id.{@item.id}_input",
+                    "fullExpression": "items_4.@item.id.{@item.id}_input",
                     "matchedExpression": "@item.id",
                     "type": "item",
                     "fieldName": "id"
@@ -221,7 +221,7 @@
               "style_list": [
                 "flex: 1"
               ],
-              "_nested_name": "items.@item.id.{@item.id}_description",
+              "_nested_name": "items_4.@item.id.{@item.id}_description",
               "_dynamicFields": {
                 "name": [
                   {
@@ -241,13 +241,13 @@
                 ],
                 "_nested_name": [
                   {
-                    "fullExpression": "items.@item.id.{@item.id}_description",
+                    "fullExpression": "items_4.@item.id.{@item.id}_description",
                     "matchedExpression": "@item.id",
                     "type": "item",
                     "fieldName": "id"
                   },
                   {
-                    "fullExpression": "items.@item.id.{@item.id}_description",
+                    "fullExpression": "items_4.@item.id.{@item.id}_description",
                     "matchedExpression": "@item.id",
                     "type": "item",
                     "fieldName": "id"
@@ -266,7 +266,7 @@
               }
             }
           ],
-          "_nested_name": "items.@item.id",
+          "_nested_name": "items_4.@item.id",
           "_dynamicFields": {
             "name": [
               {
@@ -278,7 +278,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "items.@item.id",
+                "fullExpression": "items_4.@item.id",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -293,8 +293,8 @@
           }
         }
       ],
-      "name": "items",
-      "_nested_name": "items",
+      "name": "items_4",
+      "_nested_name": "items_4",
       "_dynamicFields": {
         "value": [
           {

--- a/app_data/sheets/template/component_demo/comp_radio_group.json
+++ b/app_data/sheets/template/component_demo/comp_radio_group.json
@@ -24,10 +24,30 @@
     {
       "name": "answer_list_1",
       "value": [
-        "name:name_var_1 | text:First | image:/plh_images/icons/heart.svg | image_checked: /plh_images/icons/tick.svg",
-        "name:name_var_2 | text:Second | image:/plh_images/icons/heart.svg | image_checked: /plh_images/icons/tick.svg",
-        "name:name_var_3 | text: Third | image:/plh_images/icons/heart.svg | image_checked: /plh_images/icons/tick.svg",
-        "name:name_var_4 | text:Fourth | image:/plh_images/icons/heart.svg | image_checked: /plh_images/icons/tick.svg"
+        {
+          "name": "name_var_1",
+          "text": "First",
+          "image": "/plh_images/icons/heart.svg",
+          "image_checked": "/plh_images/icons/tick.svg"
+        },
+        {
+          "name": "name_var_2",
+          "text": "Second",
+          "image": "/plh_images/icons/heart.svg",
+          "image_checked": "/plh_images/icons/tick.svg"
+        },
+        {
+          "name": "name_var_3",
+          "text": "Third",
+          "image": "/plh_images/icons/heart.svg",
+          "image_checked": "/plh_images/icons/tick.svg"
+        },
+        {
+          "name": "name_var_4",
+          "text": "Fourth",
+          "image": "/plh_images/icons/heart.svg",
+          "image_checked": "/plh_images/icons/tick.svg"
+        }
       ],
       "type": "set_variable",
       "_nested_name": "answer_list_1"
@@ -69,11 +89,26 @@
     {
       "name": "answer_list_2",
       "value": [
-        "name:name_var_1 | text:First",
-        "name:name_var_2 | text:Second",
-        "name:name_var_3 | text:Third",
-        "name:name_var_4 | text:Fourth",
-        "name:name_var_5 | text:Fifth"
+        {
+          "name": "name_var_1",
+          "text": "First"
+        },
+        {
+          "name": "name_var_2",
+          "text": "Second"
+        },
+        {
+          "name": "name_var_3",
+          "text": "Third"
+        },
+        {
+          "name": "name_var_4",
+          "text": "Fourth"
+        },
+        {
+          "name": "name_var_5",
+          "text": "Fifth"
+        }
       ],
       "type": "set_variable",
       "_nested_name": "answer_list_2"
@@ -81,11 +116,36 @@
     {
       "name": "answer_list_3",
       "value": [
-        "name:name_var_1 | text:First | image:/plh_images/icons/heart.svg | image_checked: images/icons/globe_blue.svg",
-        "name:name_var_2 | text:Second | image:/plh_images/icons/heart.svg | image_checked: images/icons/globe_blue.svg",
-        "name:name_var_3 | text: Third | image:/plh_images/icons/heart.svg | image_checked: images/icons/globe_blue.svg",
-        "name:name_var_4 | text:Fourth | image:/plh_images/icons/heart.svg | image_checked: images/icons/globe_blue.svg",
-        "name:name_var_5 | text:Fourth | image:/plh_images/icons/heart.svg | image_checked: images/icons/globe_blue.svg"
+        {
+          "name": "name_var_1",
+          "text": "First",
+          "image": "/plh_images/icons/heart.svg",
+          "image_checked": "images/icons/globe_blue.svg"
+        },
+        {
+          "name": "name_var_2",
+          "text": "Second",
+          "image": "/plh_images/icons/heart.svg",
+          "image_checked": "images/icons/globe_blue.svg"
+        },
+        {
+          "name": "name_var_3",
+          "text": "Third",
+          "image": "/plh_images/icons/heart.svg",
+          "image_checked": "images/icons/globe_blue.svg"
+        },
+        {
+          "name": "name_var_4",
+          "text": "Fourth",
+          "image": "/plh_images/icons/heart.svg",
+          "image_checked": "images/icons/globe_blue.svg"
+        },
+        {
+          "name": "name_var_5",
+          "text": "Fourth",
+          "image": "/plh_images/icons/heart.svg",
+          "image_checked": "images/icons/globe_blue.svg"
+        }
       ],
       "type": "set_variable",
       "_nested_name": "answer_list_3"
@@ -93,11 +153,31 @@
     {
       "name": "answer_list_4",
       "value": [
-        "name:name_var_1 | image: images/icons/heart_blue.svg | image_checked: images/icons/tick.svg",
-        "name:name_var_2 | image: images/icons/heart_blue.svg | image_checked: images/icons/tick.svg",
-        "name:name_var_3 | image: images/icons/heart_blue.svg | image_checked: images/icons/tick.svg",
-        "name:name_var_4 | image: images/icons/heart_blue.svg | image_checked: images/icons/tick.svg",
-        "name:name_var_5 | image: images/icons/heart_blue.svg | image_checked: images/icons/tick.svg"
+        {
+          "name": "name_var_1",
+          "image": "images/icons/heart_blue.svg",
+          "image_checked": "images/icons/tick.svg"
+        },
+        {
+          "name": "name_var_2",
+          "image": "images/icons/heart_blue.svg",
+          "image_checked": "images/icons/tick.svg"
+        },
+        {
+          "name": "name_var_3",
+          "image": "images/icons/heart_blue.svg",
+          "image_checked": "images/icons/tick.svg"
+        },
+        {
+          "name": "name_var_4",
+          "image": "images/icons/heart_blue.svg",
+          "image_checked": "images/icons/tick.svg"
+        },
+        {
+          "name": "name_var_5",
+          "image": "images/icons/heart_blue.svg",
+          "image_checked": "images/icons/tick.svg"
+        }
       ],
       "type": "set_variable",
       "_nested_name": "answer_list_4"
@@ -105,11 +185,26 @@
     {
       "name": "answer_list_5",
       "value": [
-        "name:name_var_1 | image: images/icons/heart_blue.svg",
-        "name:name_var_2 | image: images/icons/heart_blue.svg",
-        "name:name_var_3 | image: images/icons/heart_blue.svg",
-        "name:name_var_4 | image: images/icons/heart_blue.svg",
-        "name:name_var_5 | image: images/icons/heart_blue.svg"
+        {
+          "name": "name_var_1",
+          "image": "images/icons/heart_blue.svg"
+        },
+        {
+          "name": "name_var_2",
+          "image": "images/icons/heart_blue.svg"
+        },
+        {
+          "name": "name_var_3",
+          "image": "images/icons/heart_blue.svg"
+        },
+        {
+          "name": "name_var_4",
+          "image": "images/icons/heart_blue.svg"
+        },
+        {
+          "name": "name_var_5",
+          "image": "images/icons/heart_blue.svg"
+        }
       ],
       "type": "set_variable",
       "_nested_name": "answer_list_5"

--- a/app_data/sheets/template/component_demo/comp_subtitle.json
+++ b/app_data/sheets/template/component_demo/comp_subtitle.json
@@ -90,8 +90,8 @@
         "style": "emphasised"
       },
       "type": "set_variable",
-      "name": "set_variable",
-      "_nested_name": "set_variable"
+      "name": "set_variable_12",
+      "_nested_name": "set_variable_12"
     }
   ],
   "_xlsxPath": "component_sheets/component_subtitle.xlsx"

--- a/app_data/sheets/template/component_demo/comp_task_card.json
+++ b/app_data/sheets/template/component_demo/comp_task_card.json
@@ -197,8 +197,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "title",
-      "_nested_name": "title"
+      "name": "title_15",
+      "_nested_name": "title_15"
     },
     {
       "type": "task_card",
@@ -370,8 +370,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "title",
-      "_nested_name": "title"
+      "name": "title_17",
+      "_nested_name": "title_17"
     },
     {
       "type": "task_card",
@@ -543,8 +543,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "title",
-      "_nested_name": "title"
+      "name": "title_19",
+      "_nested_name": "title_19"
     },
     {
       "type": "task_card",
@@ -716,8 +716,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "title",
-      "_nested_name": "title"
+      "name": "title_21",
+      "_nested_name": "title_21"
     },
     {
       "type": "task_card",
@@ -889,8 +889,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "title",
-      "_nested_name": "title"
+      "name": "title_23",
+      "_nested_name": "title_23"
     },
     {
       "type": "task_card",
@@ -1050,8 +1050,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "title",
-      "_nested_name": "title"
+      "name": "title_25",
+      "_nested_name": "title_25"
     },
     {
       "type": "task_card",
@@ -2048,8 +2048,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "title",
-      "_nested_name": "title"
+      "name": "title_33",
+      "_nested_name": "title_33"
     },
     {
       "type": "task_card",
@@ -2067,8 +2067,8 @@
               "_translations": {
                 "value": {}
               },
-              "name": "title",
-              "_nested_name": "card_1.display_group.title"
+              "name": "title_1",
+              "_nested_name": "card_1.display_group_1.title_1"
             },
             {
               "type": "subtitle",
@@ -2076,20 +2076,20 @@
               "_translations": {
                 "value": {}
               },
-              "name": "subtitle",
-              "_nested_name": "card_1.display_group.subtitle"
+              "name": "subtitle_2",
+              "_nested_name": "card_1.display_group_1.subtitle_2"
             },
             {
               "type": "progress_bar",
               "parameter_list": {
                 "task_group": "w_1on1"
               },
-              "name": "progress_bar",
-              "_nested_name": "card_1.display_group.progress_bar"
+              "name": "progress_bar_3",
+              "_nested_name": "card_1.display_group_1.progress_bar_3"
             }
           ],
-          "name": "display_group",
-          "_nested_name": "card_1.display_group"
+          "name": "display_group_1",
+          "_nested_name": "card_1.display_group_1"
         },
         {
           "type": "image",
@@ -2097,8 +2097,8 @@
           "_translations": {
             "value": {}
           },
-          "name": "image",
-          "_nested_name": "card_1.image"
+          "name": "image_2",
+          "_nested_name": "card_1.image_2"
         }
       ],
       "_nested_name": "card_1"

--- a/app_data/sheets/template/component_demo/comp_task_prog_bar_dynamic.json
+++ b/app_data/sheets/template/component_demo/comp_task_prog_bar_dynamic.json
@@ -10,8 +10,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "title",
-      "_nested_name": "title"
+      "name": "title_2",
+      "_nested_name": "title_2"
     },
     {
       "name": "task_group",
@@ -28,8 +28,8 @@
         "task_group_data": "@local.task_group",
         "completed_field": "comp_task_progress_bar_completed"
       },
-      "name": "task_progress_bar",
-      "_nested_name": "task_progress_bar",
+      "name": "task_progress_bar_4",
+      "_nested_name": "task_progress_bar_4",
       "_dynamicFields": {
         "parameter_list": {
           "task_group_data": [
@@ -58,8 +58,8 @@
           "_translations": {
             "value": {}
           },
-          "name": "text",
-          "_nested_name": "data_items.text",
+          "name": "text_1",
+          "_nested_name": "data_items_5.text_1",
           "_dynamicFields": {
             "value": [
               {
@@ -100,7 +100,7 @@
             "true_text": "Completed",
             "false_text": "Not completed"
           },
-          "_nested_name": "data_items.toggle_bar_@item.id",
+          "_nested_name": "data_items_5.toggle_bar_@item.id",
           "_dynamicFields": {
             "name": [
               {
@@ -150,7 +150,7 @@
             },
             "_nested_name": [
               {
-                "fullExpression": "data_items.toggle_bar_@item.id",
+                "fullExpression": "data_items_5.toggle_bar_@item.id",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -179,7 +179,7 @@
           "_translations": {
             "value": {}
           },
-          "_nested_name": "data_items.text_completed_@item.id",
+          "_nested_name": "data_items_5.text_completed_@item.id",
           "_dynamicFields": {
             "name": [
               {
@@ -199,7 +199,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "data_items.text_completed_@item.id",
+                "fullExpression": "data_items_5.text_completed_@item.id",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -235,7 +235,7 @@
               }
             }
           ],
-          "_nested_name": "data_items.toggle_button_@item.id",
+          "_nested_name": "data_items_5.toggle_button_@item.id",
           "_dynamicFields": {
             "name": [
               {
@@ -277,7 +277,7 @@
             },
             "_nested_name": [
               {
-                "fullExpression": "data_items.toggle_button_@item.id",
+                "fullExpression": "data_items_5.toggle_button_@item.id",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -297,8 +297,8 @@
           }
         }
       ],
-      "name": "data_items",
-      "_nested_name": "data_items"
+      "name": "data_items_5",
+      "_nested_name": "data_items_5"
     }
   ],
   "_xlsxPath": "component_sheets/component_task_progress_bar.xlsx"

--- a/app_data/sheets/template/component_demo/comp_task_progress_bar.json
+++ b/app_data/sheets/template/component_demo/comp_task_progress_bar.json
@@ -10,8 +10,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "title",
-      "_nested_name": "title"
+      "name": "title_2",
+      "_nested_name": "title_2"
     },
     {
       "name": "task_group",
@@ -28,8 +28,8 @@
         "task_group_data": "@local.task_group",
         "completed_field": "comp_task_progress_bar_completed"
       },
-      "name": "task_progress_bar",
-      "_nested_name": "task_progress_bar",
+      "name": "task_progress_bar_4",
+      "_nested_name": "task_progress_bar_4",
       "_dynamicFields": {
         "parameter_list": {
           "task_group_data": [
@@ -58,8 +58,8 @@
           "_translations": {
             "value": {}
           },
-          "name": "text",
-          "_nested_name": "items.text",
+          "name": "text_1",
+          "_nested_name": "items_5.text_1",
           "_dynamicFields": {
             "value": [
               {
@@ -107,7 +107,7 @@
             "true_text": "Completed",
             "false_text": "Not completed"
           },
-          "_nested_name": "items.toggle_bar_@item.id",
+          "_nested_name": "items_5.toggle_bar_@item.id",
           "_dynamicFields": {
             "name": [
               {
@@ -157,7 +157,7 @@
             },
             "_nested_name": [
               {
-                "fullExpression": "items.toggle_bar_@item.id",
+                "fullExpression": "items_5.toggle_bar_@item.id",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -178,8 +178,8 @@
           }
         }
       ],
-      "name": "items",
-      "_nested_name": "items",
+      "name": "items_5",
+      "_nested_name": "items_5",
       "_dynamicFields": {
         "value": [
           {

--- a/app_data/sheets/template/component_demo/comp_title.json
+++ b/app_data/sheets/template/component_demo/comp_title.json
@@ -33,7 +33,7 @@
           "_translations": {
             "value": {}
           },
-          "_nested_name": "display_group.text_value"
+          "_nested_name": "display_group_4.text_value"
         },
         {
           "type": "text_box",
@@ -49,7 +49,7 @@
               "_cleaned": "changed | emit:force_reprocess"
             }
           ],
-          "_nested_name": "display_group.text_box_value"
+          "_nested_name": "display_group_4.text_box_value"
         },
         {
           "type": "text",
@@ -58,11 +58,11 @@
           "_translations": {
             "value": {}
           },
-          "_nested_name": "display_group.description_value"
+          "_nested_name": "display_group_4.description_value"
         }
       ],
-      "name": "display_group",
-      "_nested_name": "display_group"
+      "name": "display_group_4",
+      "_nested_name": "display_group_4"
     },
     {
       "type": "subtitle",
@@ -84,7 +84,7 @@
           "_translations": {
             "value": {}
           },
-          "_nested_name": "display_group.text_help"
+          "_nested_name": "display_group_7.text_help"
         },
         {
           "type": "text_box",
@@ -100,7 +100,7 @@
               "_cleaned": "changed | emit:force_reprocess"
             }
           ],
-          "_nested_name": "display_group.text_box_help"
+          "_nested_name": "display_group_7.text_box_help"
         },
         {
           "type": "text",
@@ -109,11 +109,11 @@
           "_translations": {
             "value": {}
           },
-          "_nested_name": "display_group.description_value"
+          "_nested_name": "display_group_7.description_value"
         }
       ],
-      "name": "display_group",
-      "_nested_name": "display_group"
+      "name": "display_group_7",
+      "_nested_name": "display_group_7"
     },
     {
       "type": "items",
@@ -133,7 +133,7 @@
               "style_list": [
                 "width: 150px"
               ],
-              "_nested_name": "items.@item.id.{@item.id}_name",
+              "_nested_name": "items_9.@item.id.{@item.id}_name",
               "_dynamicFields": {
                 "name": [
                   {
@@ -153,13 +153,13 @@
                 ],
                 "_nested_name": [
                   {
-                    "fullExpression": "items.@item.id.{@item.id}_name",
+                    "fullExpression": "items_9.@item.id.{@item.id}_name",
                     "matchedExpression": "@item.id",
                     "type": "item",
                     "fieldName": "id"
                   },
                   {
-                    "fullExpression": "items.@item.id.{@item.id}_name",
+                    "fullExpression": "items_9.@item.id.{@item.id}_name",
                     "matchedExpression": "@item.id",
                     "type": "item",
                     "fieldName": "id"
@@ -198,7 +198,7 @@
                 }
               ],
               "exclude_from_translation": true,
-              "_nested_name": "items.@item.id.{@item.id}_input",
+              "_nested_name": "items_9.@item.id.{@item.id}_input",
               "_dynamicFields": {
                 "name": [
                   {
@@ -226,13 +226,13 @@
                 ],
                 "_nested_name": [
                   {
-                    "fullExpression": "items.@item.id.{@item.id}_input",
+                    "fullExpression": "items_9.@item.id.{@item.id}_input",
                     "matchedExpression": "@item.id",
                     "type": "item",
                     "fieldName": "id"
                   },
                   {
-                    "fullExpression": "items.@item.id.{@item.id}_input",
+                    "fullExpression": "items_9.@item.id.{@item.id}_input",
                     "matchedExpression": "@item.id",
                     "type": "item",
                     "fieldName": "id"
@@ -258,7 +258,7 @@
               "style_list": [
                 "width: 100px"
               ],
-              "_nested_name": "items.@item.id.{@item.id}_input",
+              "_nested_name": "items_9.@item.id.{@item.id}_input",
               "_dynamicFields": {
                 "name": [
                   {
@@ -278,13 +278,13 @@
                 ],
                 "_nested_name": [
                   {
-                    "fullExpression": "items.@item.id.{@item.id}_input",
+                    "fullExpression": "items_9.@item.id.{@item.id}_input",
                     "matchedExpression": "@item.id",
                     "type": "item",
                     "fieldName": "id"
                   },
                   {
-                    "fullExpression": "items.@item.id.{@item.id}_input",
+                    "fullExpression": "items_9.@item.id.{@item.id}_input",
                     "matchedExpression": "@item.id",
                     "type": "item",
                     "fieldName": "id"
@@ -312,7 +312,7 @@
               "style_list": [
                 "flex: 1"
               ],
-              "_nested_name": "items.@item.id.{@item.id}_description",
+              "_nested_name": "items_9.@item.id.{@item.id}_description",
               "_dynamicFields": {
                 "name": [
                   {
@@ -332,13 +332,13 @@
                 ],
                 "_nested_name": [
                   {
-                    "fullExpression": "items.@item.id.{@item.id}_description",
+                    "fullExpression": "items_9.@item.id.{@item.id}_description",
                     "matchedExpression": "@item.id",
                     "type": "item",
                     "fieldName": "id"
                   },
                   {
-                    "fullExpression": "items.@item.id.{@item.id}_description",
+                    "fullExpression": "items_9.@item.id.{@item.id}_description",
                     "matchedExpression": "@item.id",
                     "type": "item",
                     "fieldName": "id"
@@ -357,7 +357,7 @@
               }
             }
           ],
-          "_nested_name": "items.@item.id",
+          "_nested_name": "items_9.@item.id",
           "_dynamicFields": {
             "name": [
               {
@@ -369,7 +369,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "items.@item.id",
+                "fullExpression": "items_9.@item.id",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -384,8 +384,8 @@
           }
         }
       ],
-      "name": "items",
-      "_nested_name": "items",
+      "name": "items_9",
+      "_nested_name": "items_9",
       "_dynamicFields": {
         "value": [
           {

--- a/app_data/sheets/template/component_demo/example_task_carousel.json
+++ b/app_data/sheets/template/component_demo/example_task_carousel.json
@@ -10,8 +10,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "title",
-      "_nested_name": "title"
+      "name": "title_2",
+      "_nested_name": "title_2"
     },
     {
       "name": "task_groups_data",
@@ -28,8 +28,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "text",
-      "_nested_name": "text",
+      "name": "text_4",
+      "_nested_name": "text_4",
       "_dynamicFields": {
         "value": [
           {
@@ -68,7 +68,7 @@
                     "value": {}
                   },
                   "type": "set_variable",
-                  "_nested_name": "carousel.items.module_card.workshop_id",
+                  "_nested_name": "carousel_5.items_1.module_card.workshop_id",
                   "_dynamicFields": {
                     "value": [
                       {
@@ -87,11 +87,11 @@
                 }
               ],
               "name": "module_card",
-              "_nested_name": "carousel.items.module_card"
+              "_nested_name": "carousel_5.items_1.module_card"
             }
           ],
-          "name": "items",
-          "_nested_name": "carousel.items",
+          "name": "items_1",
+          "_nested_name": "carousel_5.items_1",
           "_dynamicFields": {
             "value": [
               {
@@ -109,8 +109,8 @@
           }
         }
       ],
-      "name": "carousel",
-      "_nested_name": "carousel",
+      "name": "carousel_5",
+      "_nested_name": "carousel_5",
       "_dynamicFields": {
         "parameter_list": {
           "task_groups_data": [

--- a/app_data/sheets/template/component_demo/feat_animated_slides.json
+++ b/app_data/sheets/template/component_demo/feat_animated_slides.json
@@ -50,11 +50,11 @@
                   "_translations": {
                     "value": {}
                   },
-                  "_nested_name": "animated_slides.animated_section.display_group.image_1"
+                  "_nested_name": "animated_slides_2.animated_section_1.display_group_1.image_1"
                 }
               ],
-              "name": "display_group",
-              "_nested_name": "animated_slides.animated_section.display_group"
+              "name": "display_group_1",
+              "_nested_name": "animated_slides_2.animated_section_1.display_group_1"
             },
             {
               "type": "text",
@@ -65,12 +65,12 @@
               "parameter_list": {
                 "style": "large center"
               },
-              "name": "text",
-              "_nested_name": "animated_slides.animated_section.text"
+              "name": "text_2",
+              "_nested_name": "animated_slides_2.animated_section_1.text_2"
             }
           ],
-          "name": "animated_section",
-          "_nested_name": "animated_slides.animated_section"
+          "name": "animated_section_1",
+          "_nested_name": "animated_slides_2.animated_section_1"
         },
         {
           "type": "animated_section",
@@ -92,11 +92,11 @@
                   "_translations": {
                     "value": {}
                   },
-                  "_nested_name": "animated_slides.animated_section.display_group.image_2"
+                  "_nested_name": "animated_slides_2.animated_section_2.display_group_1.image_2"
                 }
               ],
-              "name": "display_group",
-              "_nested_name": "animated_slides.animated_section.display_group"
+              "name": "display_group_1",
+              "_nested_name": "animated_slides_2.animated_section_2.display_group_1"
             },
             {
               "type": "text",
@@ -107,12 +107,12 @@
               "parameter_list": {
                 "style": "large center"
               },
-              "name": "text",
-              "_nested_name": "animated_slides.animated_section.text"
+              "name": "text_2",
+              "_nested_name": "animated_slides_2.animated_section_2.text_2"
             }
           ],
-          "name": "animated_section",
-          "_nested_name": "animated_slides.animated_section"
+          "name": "animated_section_2",
+          "_nested_name": "animated_slides_2.animated_section_2"
         },
         {
           "type": "animated_section",
@@ -130,8 +130,8 @@
               "parameter_list": {
                 "style": "large center"
               },
-              "name": "text",
-              "_nested_name": "animated_slides.animated_section.text"
+              "name": "text_1",
+              "_nested_name": "animated_slides_2.animated_section_3.text_1"
             },
             {
               "type": "display_group",
@@ -146,7 +146,7 @@
                   "_translations": {
                     "value": {}
                   },
-                  "_nested_name": "animated_slides.animated_section.display_group.image_3"
+                  "_nested_name": "animated_slides_2.animated_section_3.display_group_2.image_3"
                 },
                 {
                   "type": "image",
@@ -155,11 +155,11 @@
                   "_translations": {
                     "value": {}
                   },
-                  "_nested_name": "animated_slides.animated_section.display_group.image_4"
+                  "_nested_name": "animated_slides_2.animated_section_3.display_group_2.image_4"
                 }
               ],
-              "name": "display_group",
-              "_nested_name": "animated_slides.animated_section.display_group"
+              "name": "display_group_2",
+              "_nested_name": "animated_slides_2.animated_section_3.display_group_2"
             },
             {
               "type": "display_group",
@@ -174,15 +174,15 @@
                   "_translations": {
                     "value": {}
                   },
-                  "_nested_name": "animated_slides.animated_section.display_group.image_5"
+                  "_nested_name": "animated_slides_2.animated_section_3.display_group_3.image_5"
                 }
               ],
-              "name": "display_group",
-              "_nested_name": "animated_slides.animated_section.display_group"
+              "name": "display_group_3",
+              "_nested_name": "animated_slides_2.animated_section_3.display_group_3"
             }
           ],
-          "name": "animated_section",
-          "_nested_name": "animated_slides.animated_section"
+          "name": "animated_section_3",
+          "_nested_name": "animated_slides_2.animated_section_3"
         },
         {
           "type": "animated_section",
@@ -204,11 +204,11 @@
                   "_translations": {
                     "value": {}
                   },
-                  "_nested_name": "animated_slides.animated_section.display_group.image_6"
+                  "_nested_name": "animated_slides_2.animated_section_4.display_group_1.image_6"
                 }
               ],
-              "name": "display_group",
-              "_nested_name": "animated_slides.animated_section.display_group"
+              "name": "display_group_1",
+              "_nested_name": "animated_slides_2.animated_section_4.display_group_1"
             },
             {
               "type": "text",
@@ -216,16 +216,16 @@
               "_translations": {
                 "value": {}
               },
-              "name": "text",
-              "_nested_name": "animated_slides.animated_section.text"
+              "name": "text_2",
+              "_nested_name": "animated_slides_2.animated_section_4.text_2"
             }
           ],
-          "name": "animated_section",
-          "_nested_name": "animated_slides.animated_section"
+          "name": "animated_section_4",
+          "_nested_name": "animated_slides_2.animated_section_4"
         }
       ],
-      "name": "animated_slides",
-      "_nested_name": "animated_slides"
+      "name": "animated_slides_2",
+      "_nested_name": "animated_slides_2"
     }
   ],
   "_xlsxPath": "feature_sheets/feature_animated_slides.xlsx"

--- a/app_data/sheets/template/component_demo/feature_task_card_params.json
+++ b/app_data/sheets/template/component_demo/feature_task_card_params.json
@@ -73,8 +73,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "title",
-      "_nested_name": "title"
+      "name": "title_9",
+      "_nested_name": "title_9"
     },
     {
       "name": "highlighted_text",
@@ -104,8 +104,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "text",
-      "_nested_name": "text",
+      "name": "text_12",
+      "_nested_name": "text_12",
       "_dynamicFields": {
         "value": [
           {
@@ -128,8 +128,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "text",
-      "_nested_name": "text",
+      "name": "text_13",
+      "_nested_name": "text_13",
       "_dynamicFields": {
         "value": [
           {
@@ -319,8 +319,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "title",
-      "_nested_name": "title"
+      "name": "title_15",
+      "_nested_name": "title_15"
     },
     {
       "type": "task_card",

--- a/app_data/sheets/template/component_demo/parameters.json
+++ b/app_data/sheets/template/component_demo/parameters.json
@@ -42,7 +42,7 @@
               "style_list": [
                 "width: 150px"
               ],
-              "_nested_name": "items.@item.id.{@item.id}_name",
+              "_nested_name": "items_4.@item.id.{@item.id}_name",
               "_dynamicFields": {
                 "name": [
                   {
@@ -62,13 +62,13 @@
                 ],
                 "_nested_name": [
                   {
-                    "fullExpression": "items.@item.id.{@item.id}_name",
+                    "fullExpression": "items_4.@item.id.{@item.id}_name",
                     "matchedExpression": "@item.id",
                     "type": "item",
                     "fieldName": "id"
                   },
                   {
-                    "fullExpression": "items.@item.id.{@item.id}_name",
+                    "fullExpression": "items_4.@item.id.{@item.id}_name",
                     "matchedExpression": "@item.id",
                     "type": "item",
                     "fieldName": "id"
@@ -107,7 +107,7 @@
                 }
               ],
               "exclude_from_translation": true,
-              "_nested_name": "items.@item.id.{@item.id}_input",
+              "_nested_name": "items_4.@item.id.{@item.id}_input",
               "_dynamicFields": {
                 "name": [
                   {
@@ -135,13 +135,13 @@
                 ],
                 "_nested_name": [
                   {
-                    "fullExpression": "items.@item.id.{@item.id}_input",
+                    "fullExpression": "items_4.@item.id.{@item.id}_input",
                     "matchedExpression": "@item.id",
                     "type": "item",
                     "fieldName": "id"
                   },
                   {
-                    "fullExpression": "items.@item.id.{@item.id}_input",
+                    "fullExpression": "items_4.@item.id.{@item.id}_input",
                     "matchedExpression": "@item.id",
                     "type": "item",
                     "fieldName": "id"
@@ -167,7 +167,7 @@
               "style_list": [
                 "width: 100px"
               ],
-              "_nested_name": "items.@item.id.{@item.id}_input",
+              "_nested_name": "items_4.@item.id.{@item.id}_input",
               "_dynamicFields": {
                 "name": [
                   {
@@ -187,13 +187,13 @@
                 ],
                 "_nested_name": [
                   {
-                    "fullExpression": "items.@item.id.{@item.id}_input",
+                    "fullExpression": "items_4.@item.id.{@item.id}_input",
                     "matchedExpression": "@item.id",
                     "type": "item",
                     "fieldName": "id"
                   },
                   {
-                    "fullExpression": "items.@item.id.{@item.id}_input",
+                    "fullExpression": "items_4.@item.id.{@item.id}_input",
                     "matchedExpression": "@item.id",
                     "type": "item",
                     "fieldName": "id"
@@ -221,7 +221,7 @@
               "style_list": [
                 "flex: 1"
               ],
-              "_nested_name": "items.@item.id.{@item.id}_description",
+              "_nested_name": "items_4.@item.id.{@item.id}_description",
               "_dynamicFields": {
                 "name": [
                   {
@@ -241,13 +241,13 @@
                 ],
                 "_nested_name": [
                   {
-                    "fullExpression": "items.@item.id.{@item.id}_description",
+                    "fullExpression": "items_4.@item.id.{@item.id}_description",
                     "matchedExpression": "@item.id",
                     "type": "item",
                     "fieldName": "id"
                   },
                   {
-                    "fullExpression": "items.@item.id.{@item.id}_description",
+                    "fullExpression": "items_4.@item.id.{@item.id}_description",
                     "matchedExpression": "@item.id",
                     "type": "item",
                     "fieldName": "id"
@@ -266,7 +266,7 @@
               }
             }
           ],
-          "_nested_name": "items.@item.id",
+          "_nested_name": "items_4.@item.id",
           "_dynamicFields": {
             "name": [
               {
@@ -278,7 +278,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "items.@item.id",
+                "fullExpression": "items_4.@item.id",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -293,8 +293,8 @@
           }
         }
       ],
-      "name": "items",
-      "_nested_name": "items",
+      "name": "items_4",
+      "_nested_name": "items_4",
       "_dynamicFields": {
         "value": [
           {

--- a/app_data/sheets/template/component_demo/parameters_3.json
+++ b/app_data/sheets/template/component_demo/parameters_3.json
@@ -9,8 +9,8 @@
       "required": true,
       "description": "List of options presented as radio items",
       "type": "set_variable",
-      "name": "set_variable",
-      "_nested_name": "set_variable"
+      "name": "set_variable_2",
+      "_nested_name": "set_variable_2"
     },
     {
       "id": "item_width",
@@ -18,8 +18,8 @@
       "description": "Minimum item width, will increase to fit grid;",
       "default_value": "200px",
       "type": "set_variable",
-      "name": "set_variable",
-      "_nested_name": "set_variable"
+      "name": "set_variable_3",
+      "_nested_name": "set_variable_3"
     },
     {
       "id": "grid_width",
@@ -27,8 +27,8 @@
       "description": "Maximum grid width, if specified will center items in available space.\nUse fixed or relative units, such as '75%' or '500px'",
       "default_value": "100%",
       "type": "set_variable",
-      "name": "set_variable",
-      "_nested_name": "set_variable"
+      "name": "set_variable_4",
+      "_nested_name": "set_variable_4"
     },
     {
       "id": "grid_gap",
@@ -36,8 +36,8 @@
       "description": "Spacing between grid items",
       "default_value": "16px",
       "type": "set_variable",
-      "name": "set_variable",
-      "_nested_name": "set_variable"
+      "name": "set_variable_5",
+      "_nested_name": "set_variable_5"
     }
   ],
   "_xlsxPath": "component_sheets/component_accordion.xlsx"

--- a/app_data/sheets/template/debug/debug_accordion_variables.json
+++ b/app_data/sheets/template/debug/debug_accordion_variables.json
@@ -28,7 +28,7 @@
                 "value": {}
               },
               "type": "set_variable",
-              "_nested_name": "accordion.items.variable",
+              "_nested_name": "accordion.items_2.variable",
               "_dynamicFields": {
                 "value": [
                   {
@@ -57,7 +57,7 @@
                   "_translations": {
                     "value": {}
                   },
-                  "_nested_name": "accordion.items.accordion_section_@item.id.text",
+                  "_nested_name": "accordion.items_2.accordion_section_@item.id.text",
                   "_dynamicFields": {
                     "value": [
                       {
@@ -69,7 +69,7 @@
                     ],
                     "_nested_name": [
                       {
-                        "fullExpression": "accordion.items.accordion_section_@item.id.text",
+                        "fullExpression": "accordion.items_2.accordion_section_@item.id.text",
                         "matchedExpression": "@item.id.text",
                         "type": "item",
                         "fieldName": "id"
@@ -86,7 +86,7 @@
                   }
                 }
               ],
-              "_nested_name": "accordion.items.accordion_section_@item.id",
+              "_nested_name": "accordion.items_2.accordion_section_@item.id",
               "_dynamicFields": {
                 "name": [
                   {
@@ -106,7 +106,7 @@
                 ],
                 "_nested_name": [
                   {
-                    "fullExpression": "accordion.items.accordion_section_@item.id",
+                    "fullExpression": "accordion.items_2.accordion_section_@item.id",
                     "matchedExpression": "@item.id",
                     "type": "item",
                     "fieldName": "id"
@@ -124,8 +124,8 @@
               }
             }
           ],
-          "name": "items",
-          "_nested_name": "accordion.items",
+          "name": "items_2",
+          "_nested_name": "accordion.items_2",
           "_dynamicFields": {
             "value": [
               {

--- a/app_data/sheets/template/debug/debug_advanced_dashed_box_1.json
+++ b/app_data/sheets/template/debug/debug_advanced_dashed_box_1.json
@@ -19,8 +19,8 @@
             "style": "emphasised center"
           },
           "exclude_from_translation": true,
-          "name": "subtitle",
-          "_nested_name": "dashed_box_test.subtitle"
+          "name": "subtitle_1",
+          "_nested_name": "dashed_box_test.subtitle_1"
         },
         {
           "type": "display_group",
@@ -34,8 +34,8 @@
                 "value": {}
               },
               "exclude_from_translation": true,
-              "name": "button",
-              "_nested_name": "dashed_box_test.display_group.button"
+              "name": "button_1",
+              "_nested_name": "dashed_box_test.display_group.button_1"
             }
           ],
           "_nested_name": "dashed_box_test.display_group"
@@ -46,14 +46,14 @@
     {
       "exclude_from_translation": true,
       "type": "set_variable",
-      "name": "set_variable",
-      "_nested_name": "set_variable"
+      "name": "set_variable_4",
+      "_nested_name": "set_variable_4"
     },
     {
       "exclude_from_translation": true,
       "type": "set_variable",
-      "name": "set_variable",
-      "_nested_name": "set_variable"
+      "name": "set_variable_5",
+      "_nested_name": "set_variable_5"
     },
     {
       "type": "display_group",
@@ -74,8 +74,8 @@
             "text_align": "center"
           },
           "exclude_from_translation": true,
-          "name": "subtitle",
-          "_nested_name": "display_group.subtitle"
+          "name": "subtitle_1",
+          "_nested_name": "display_group.subtitle_1"
         },
         {
           "type": "parent_point_box",
@@ -94,8 +94,8 @@
     {
       "exclude_from_translation": true,
       "type": "set_variable",
-      "name": "set_variable",
-      "_nested_name": "set_variable"
+      "name": "set_variable_8",
+      "_nested_name": "set_variable_8"
     },
     {
       "type": "display_group",
@@ -115,8 +115,8 @@
             "style": "emphasised center"
           },
           "exclude_from_translation": true,
-          "name": "subtitle",
-          "_nested_name": "display_group.subtitle"
+          "name": "subtitle_1",
+          "_nested_name": "display_group.subtitle_1"
         },
         {
           "type": "parent_point_box",
@@ -148,8 +148,8 @@
             "text_align": "center"
           },
           "exclude_from_translation": true,
-          "name": "subtitle",
-          "_nested_name": "display_group.subtitle"
+          "name": "subtitle_1",
+          "_nested_name": "display_group.subtitle_1"
         },
         {
           "type": "parent_point_box",

--- a/app_data/sheets/template/debug/debug_calc_functions.json
+++ b/app_data/sheets/template/debug/debug_calc_functions.json
@@ -122,8 +122,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "title",
-      "_nested_name": "title"
+      "name": "title_7",
+      "_nested_name": "title_7"
     },
     {
       "type": "text",
@@ -131,8 +131,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "text",
-      "_nested_name": "text",
+      "name": "text_8",
+      "_nested_name": "text_8",
       "_dynamicFields": {
         "value": [
           {
@@ -155,8 +155,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "title",
-      "_nested_name": "title"
+      "name": "title_9",
+      "_nested_name": "title_9"
     },
     {
       "type": "text",
@@ -164,8 +164,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "text",
-      "_nested_name": "text"
+      "name": "text_10",
+      "_nested_name": "text_10"
     },
     {
       "type": "text",
@@ -173,8 +173,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "text",
-      "_nested_name": "text"
+      "name": "text_11",
+      "_nested_name": "text_11"
     },
     {
       "name": "plh_add_family_result",
@@ -215,8 +215,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "text",
-      "_nested_name": "text",
+      "name": "text_13",
+      "_nested_name": "text_13",
       "_dynamicFields": {
         "value": [
           {
@@ -248,8 +248,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "title",
-      "_nested_name": "title"
+      "name": "title_14",
+      "_nested_name": "title_14"
     },
     {
       "type": "text",
@@ -257,8 +257,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "text",
-      "_nested_name": "text"
+      "name": "text_15",
+      "_nested_name": "text_15"
     },
     {
       "type": "text",
@@ -266,8 +266,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "text",
-      "_nested_name": "text"
+      "name": "text_16",
+      "_nested_name": "text_16"
     },
     {
       "name": "plh_merge_families_result",
@@ -326,8 +326,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "text",
-      "_nested_name": "text",
+      "name": "text_18",
+      "_nested_name": "text_18",
       "_dynamicFields": {
         "value": [
           {
@@ -359,8 +359,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "title",
-      "_nested_name": "title"
+      "name": "title_19",
+      "_nested_name": "title_19"
     },
     {
       "type": "text",
@@ -368,8 +368,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "text",
-      "_nested_name": "text"
+      "name": "text_20",
+      "_nested_name": "text_20"
     },
     {
       "type": "text",
@@ -377,8 +377,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "text",
-      "_nested_name": "text"
+      "name": "text_21",
+      "_nested_name": "text_21"
     },
     {
       "name": "plh_remove_family_member_result",
@@ -428,8 +428,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "text",
-      "_nested_name": "text",
+      "name": "text_23",
+      "_nested_name": "text_23",
       "_dynamicFields": {
         "value": [
           {

--- a/app_data/sheets/template/debug/debug_campaign_tester.json
+++ b/app_data/sheets/template/debug/debug_campaign_tester.json
@@ -74,9 +74,18 @@
     {
       "name": "answer_list",
       "value": [
-        "name: debug_daily | text: debug_daily",
-        "name: debug_actions | text: debug_actions",
-        "name: debug_calc | text: debug_calc"
+        {
+          "name": "debug_daily",
+          "text": "debug_daily"
+        },
+        {
+          "name": "debug_actions",
+          "text": "debug_actions"
+        },
+        {
+          "name": "debug_calc",
+          "text": "debug_calc"
+        }
       ],
       "type": "set_variable",
       "_nested_name": "answer_list"
@@ -171,7 +180,7 @@
             "value": {}
           },
           "exclude_from_translation": true,
-          "_nested_name": "display_group.campaign_id",
+          "_nested_name": "display_group_8.campaign_id",
           "_dynamicFields": {
             "value": [
               {
@@ -211,7 +220,7 @@
           "style_list": [
             "padding: 0"
           ],
-          "_nested_name": "display_group.campaign_quickstart",
+          "_nested_name": "display_group_8.campaign_quickstart",
           "_dynamicFields": {
             "action_list": {
               "0": {
@@ -277,8 +286,8 @@
           }
         }
       ],
-      "name": "display_group",
-      "_nested_name": "display_group",
+      "name": "display_group_8",
+      "_nested_name": "display_group_8",
       "_dynamicFields": {
         "condition": [
           {

--- a/app_data/sheets/template/debug/debug_changed_radio_group_1.json
+++ b/app_data/sheets/template/debug/debug_changed_radio_group_1.json
@@ -24,8 +24,14 @@
     {
       "name": "answer_list_2",
       "value": [
-        "name:name_var_1 | text:First",
-        "name:name_var_2 | text:Second"
+        {
+          "name": "name_var_1",
+          "text": "First"
+        },
+        {
+          "name": "name_var_2",
+          "text": "Second"
+        }
       ],
       "exclude_from_translation": true,
       "type": "set_variable",

--- a/app_data/sheets/template/debug/debug_changed_radio_group_2.json
+++ b/app_data/sheets/template/debug/debug_changed_radio_group_2.json
@@ -14,8 +14,14 @@
     {
       "name": "answer_list_2",
       "value": [
-        "name:name_var_1 | text:First",
-        "name:name_var_2 | text:Second"
+        {
+          "name": "name_var_1",
+          "text": "First"
+        },
+        {
+          "name": "name_var_2",
+          "text": "Second"
+        }
       ],
       "exclude_from_translation": true,
       "type": "set_variable",

--- a/app_data/sheets/template/debug/debug_changed_radio_group_3.json
+++ b/app_data/sheets/template/debug/debug_changed_radio_group_3.json
@@ -14,8 +14,14 @@
     {
       "name": "answer_list_2",
       "value": [
-        "name:name_var_1 | text:First",
-        "name:name_var_2 | text:Second"
+        {
+          "name": "name_var_1",
+          "text": "First"
+        },
+        {
+          "name": "name_var_2",
+          "text": "Second"
+        }
       ],
       "exclude_from_translation": true,
       "type": "set_variable",

--- a/app_data/sheets/template/debug/debug_changed_radio_group_4.json
+++ b/app_data/sheets/template/debug/debug_changed_radio_group_4.json
@@ -14,8 +14,14 @@
     {
       "name": "answer_list_2",
       "value": [
-        "name:name_var_1 | text:First",
-        "name:name_var_2 | text:Second"
+        {
+          "name": "name_var_1",
+          "text": "First"
+        },
+        {
+          "name": "name_var_2",
+          "text": "Second"
+        }
       ],
       "exclude_from_translation": true,
       "type": "set_variable",

--- a/app_data/sheets/template/debug/debug_combo_box_dynamic.json
+++ b/app_data/sheets/template/debug/debug_combo_box_dynamic.json
@@ -7,9 +7,18 @@
     {
       "name": "answer_list",
       "value": [
-        "name: name_1 | text: This is text 1",
-        "name: name_2 | text: This is text 2",
-        "name: name_3 | text: This is text 3"
+        {
+          "name": "name_1",
+          "text": "This is text 1"
+        },
+        {
+          "name": "name_2",
+          "text": "This is text 2"
+        },
+        {
+          "name": "name_3",
+          "text": "This is text 3"
+        }
       ],
       "exclude_from_translation": true,
       "type": "set_variable",

--- a/app_data/sheets/template/debug/debug_combo_box_in_dg.json
+++ b/app_data/sheets/template/debug/debug_combo_box_in_dg.json
@@ -24,9 +24,18 @@
         {
           "name": "answer_list_challenge_1",
           "value": [
-            "name:choice_1_a | text: choice_1_a",
-            "name:choice_1_b | text: choice_1_b",
-            "name:choice_1_c | text: choice_1_c"
+            {
+              "name": "choice_1_a",
+              "text": "choice_1_a"
+            },
+            {
+              "name": "choice_1_b",
+              "text": "choice_1_b"
+            },
+            {
+              "name": "choice_1_c",
+              "text": "choice_1_c"
+            }
           ],
           "exclude_from_translation": true,
           "type": "set_variable",
@@ -170,9 +179,18 @@
         {
           "name": "answer_list_challenge_2",
           "value": [
-            "name:choice_2_a | text: choice_2_a",
-            "name:choice_2_b | text: choice_2_b",
-            "name:choice_2_c | text: choice_2_c"
+            {
+              "name": "choice_2_a",
+              "text": "choice_2_a"
+            },
+            {
+              "name": "choice_2_b",
+              "text": "choice_2_b"
+            },
+            {
+              "name": "choice_2_c",
+              "text": "choice_2_c"
+            }
           ],
           "exclude_from_translation": true,
           "type": "set_variable",

--- a/app_data/sheets/template/debug/debug_combo_box_input.json
+++ b/app_data/sheets/template/debug/debug_combo_box_input.json
@@ -7,9 +7,18 @@
     {
       "name": "answer_list",
       "value": [
-        "name: name_1 | text: This is text 1",
-        "name: name_2 | text: This is text 2",
-        "name: name_3 | text: This is text 3"
+        {
+          "name": "name_1",
+          "text": "This is text 1"
+        },
+        {
+          "name": "name_2",
+          "text": "This is text 2"
+        },
+        {
+          "name": "name_3",
+          "text": "This is text 3"
+        }
       ],
       "exclude_from_translation": true,
       "type": "set_variable",

--- a/app_data/sheets/template/debug/debug_combo_box_input_var.json
+++ b/app_data/sheets/template/debug/debug_combo_box_input_var.json
@@ -7,9 +7,18 @@
     {
       "name": "answer_list",
       "value": [
-        "name: name_1 | text: This is text 1",
-        "name: name_2 | text: This is text 2",
-        "name: name_3 | text: This is text 3"
+        {
+          "name": "name_1",
+          "text": "This is text 1"
+        },
+        {
+          "name": "name_2",
+          "text": "This is text 2"
+        },
+        {
+          "name": "name_3",
+          "text": "This is text 3"
+        }
       ],
       "exclude_from_translation": true,
       "type": "set_variable",

--- a/app_data/sheets/template/debug/debug_combo_box_not_in_dg.json
+++ b/app_data/sheets/template/debug/debug_combo_box_not_in_dg.json
@@ -17,9 +17,18 @@
     {
       "name": "answer_list_challenge_1",
       "value": [
-        "name:choice_1_a | text: choice_1_a",
-        "name:choice_1_b | text: choice_1_b",
-        "name:choice_1_c | text: choice_1_c"
+        {
+          "name": "choice_1_a",
+          "text": "choice_1_a"
+        },
+        {
+          "name": "choice_1_b",
+          "text": "choice_1_b"
+        },
+        {
+          "name": "choice_1_c",
+          "text": "choice_1_c"
+        }
       ],
       "exclude_from_translation": true,
       "type": "set_variable",
@@ -153,9 +162,18 @@
     {
       "name": "answer_list_challenge_2",
       "value": [
-        "name:choice_2_a | text: choice_2_a",
-        "name:choice_2_b | text: choice_2_b",
-        "name:choice_2_c | text: choice_2_c"
+        {
+          "name": "choice_2_a",
+          "text": "choice_2_a"
+        },
+        {
+          "name": "choice_2_b",
+          "text": "choice_2_b"
+        },
+        {
+          "name": "choice_2_c",
+          "text": "choice_2_c"
+        }
       ],
       "exclude_from_translation": true,
       "type": "set_variable",

--- a/app_data/sheets/template/debug/debug_combo_box_value.json
+++ b/app_data/sheets/template/debug/debug_combo_box_value.json
@@ -7,9 +7,18 @@
     {
       "name": "answer_list",
       "value": [
-        "name: name_1 | text: This is text 1",
-        "name: name_2 | text: This is text 2",
-        "name: name_3 | text: This is text 3"
+        {
+          "name": "name_1",
+          "text": "This is text 1"
+        },
+        {
+          "name": "name_2",
+          "text": "This is text 2"
+        },
+        {
+          "name": "name_3",
+          "text": "This is text 3"
+        }
       ],
       "exclude_from_translation": true,
       "type": "set_variable",

--- a/app_data/sheets/template/debug/debug_combo_box_variables.json
+++ b/app_data/sheets/template/debug/debug_combo_box_variables.json
@@ -7,9 +7,18 @@
     {
       "name": "answer_1_list",
       "value": [
-        "name: name_1 | text: This is text 1",
-        "name: name_2 | text: This is text 2",
-        "name: name_3 | text: This is text 3"
+        {
+          "name": "name_1",
+          "text": "This is text 1"
+        },
+        {
+          "name": "name_2",
+          "text": "This is text 2"
+        },
+        {
+          "name": "name_3",
+          "text": "This is text 3"
+        }
       ],
       "exclude_from_translation": true,
       "type": "set_variable",
@@ -48,88 +57,113 @@
     {
       "name": "answer_2_list",
       "value": [
-        "name: name_1 | text: @local.option_1",
-        "name: name_2 | text: @local.option_2",
-        "name: name_3 | text: @local.option_3"
+        {
+          "name": "name_1",
+          "text": "@local.option_1"
+        },
+        {
+          "name": "name_2",
+          "text": "@local.option_2"
+        },
+        {
+          "name": "name_3",
+          "text": "@local.option_3"
+        }
       ],
       "exclude_from_translation": true,
       "type": "set_variable",
       "_nested_name": "answer_2_list",
       "_dynamicFields": {
         "value": {
-          "0": [
-            {
-              "fullExpression": "name: name_1 | text: @local.option_1",
-              "matchedExpression": "@local.option_1",
-              "type": "local",
-              "fieldName": "option_1"
-            }
-          ],
-          "1": [
-            {
-              "fullExpression": "name: name_2 | text: @local.option_2",
-              "matchedExpression": "@local.option_2",
-              "type": "local",
-              "fieldName": "option_2"
-            }
-          ],
-          "2": [
-            {
-              "fullExpression": "name: name_3 | text: @local.option_3",
-              "matchedExpression": "@local.option_3",
-              "type": "local",
-              "fieldName": "option_3"
-            }
-          ]
+          "0": {
+            "text": [
+              {
+                "fullExpression": "@local.option_1",
+                "matchedExpression": "@local.option_1",
+                "type": "local",
+                "fieldName": "option_1"
+              }
+            ]
+          },
+          "1": {
+            "text": [
+              {
+                "fullExpression": "@local.option_2",
+                "matchedExpression": "@local.option_2",
+                "type": "local",
+                "fieldName": "option_2"
+              }
+            ]
+          },
+          "2": {
+            "text": [
+              {
+                "fullExpression": "@local.option_3",
+                "matchedExpression": "@local.option_3",
+                "type": "local",
+                "fieldName": "option_3"
+              }
+            ]
+          }
         }
       },
       "_dynamicDependencies": {
         "@local.option_1": [
-          "value.0"
+          "value.0.text"
         ],
         "@local.option_2": [
-          "value.1"
+          "value.1.text"
         ],
         "@local.option_3": [
-          "value.2"
+          "value.2.text"
         ]
       }
     },
     {
       "name": "answer_3_list",
       "value": [
-        "name: name_1 | text: @global.example_global_constant_text",
-        "name: name_2 | text: @global.example_global_constant_title"
+        {
+          "name": "name_1",
+          "text": "@global.example_global_constant_text"
+        },
+        {
+          "name": "name_2",
+          "text": "@global.example_global_constant_title"
+        }
       ],
       "exclude_from_translation": true,
       "type": "set_variable",
       "_nested_name": "answer_3_list",
       "_dynamicFields": {
         "value": {
-          "0": [
-            {
-              "fullExpression": "name: name_1 | text: @global.example_global_constant_text",
-              "matchedExpression": "@global.example_global_constant_text",
-              "type": "global",
-              "fieldName": "example_global_constant_text"
-            }
-          ],
-          "1": [
-            {
-              "fullExpression": "name: name_2 | text: @global.example_global_constant_title",
-              "matchedExpression": "@global.example_global_constant_title",
-              "type": "global",
-              "fieldName": "example_global_constant_title"
-            }
-          ]
+          "0": {
+            "text": [
+              {
+                "fullExpression": "@global.example_global_constant_text",
+                "matchedExpression": "@global.example_global_constant_text",
+                "type": "global",
+                "fieldName": "example_global_constant_text"
+              }
+            ]
+          },
+          "1": {
+            "text": [
+              {
+                "fullExpression": "@global.example_global_constant_title",
+                "matchedExpression": "@global.example_global_constant_title",
+                "type": "global",
+                "fieldName": "example_global_constant_title"
+              }
+            ]
+          }
         }
       },
       "_dynamicDependencies": {
         "@global.example_global_constant_text": [
-          "value.0"
+          "value.0.text"
         ],
         "@global.example_global_constant_title": [
-          "value.1"
+          "value.1.text"
         ]
       }
     },
@@ -354,134 +388,184 @@
     {
       "name": "answer_list",
       "value": [
-        "name:name_1 | text:@local.spend_time_idea_1",
-        "name:name_2 | text:@local.spend_time_idea_2",
-        "name:name_3 | text:@local.spend_time_idea_3",
-        "name:name_4 | text:@local.spend_time_idea_4",
-        "name:name_5 | text:@local.spend_time_idea_5",
-        "name:name_6 | text:@local.spend_time_idea_6",
-        "name:name_7 | text:@local.spend_time_idea_7",
-        "name:name_8 | text:@local.spend_time_idea_8",
-        "name:name_9 | text:@local.spend_time_idea_9",
-        "name:name_10 | text:@local.spend_time_idea_10"
+        {
+          "name": "name_1",
+          "text": "@local.spend_time_idea_1"
+        },
+        {
+          "name": "name_2",
+          "text": "@local.spend_time_idea_2"
+        },
+        {
+          "name": "name_3",
+          "text": "@local.spend_time_idea_3"
+        },
+        {
+          "name": "name_4",
+          "text": "@local.spend_time_idea_4"
+        },
+        {
+          "name": "name_5",
+          "text": "@local.spend_time_idea_5"
+        },
+        {
+          "name": "name_6",
+          "text": "@local.spend_time_idea_6"
+        },
+        {
+          "name": "name_7",
+          "text": "@local.spend_time_idea_7"
+        },
+        {
+          "name": "name_8",
+          "text": "@local.spend_time_idea_8"
+        },
+        {
+          "name": "name_9",
+          "text": "@local.spend_time_idea_9"
+        },
+        {
+          "name": "name_10",
+          "text": "@local.spend_time_idea_10"
+        }
       ],
       "exclude_from_translation": true,
       "type": "set_variable",
       "_nested_name": "answer_list",
       "_dynamicFields": {
         "value": {
-          "0": [
-            {
-              "fullExpression": "name:name_1 | text:@local.spend_time_idea_1",
-              "matchedExpression": "@local.spend_time_idea_1",
-              "type": "local",
-              "fieldName": "spend_time_idea_1"
-            }
-          ],
-          "1": [
-            {
-              "fullExpression": "name:name_2 | text:@local.spend_time_idea_2",
-              "matchedExpression": "@local.spend_time_idea_2",
-              "type": "local",
-              "fieldName": "spend_time_idea_2"
-            }
-          ],
-          "2": [
-            {
-              "fullExpression": "name:name_3 | text:@local.spend_time_idea_3",
-              "matchedExpression": "@local.spend_time_idea_3",
-              "type": "local",
-              "fieldName": "spend_time_idea_3"
-            }
-          ],
-          "3": [
-            {
-              "fullExpression": "name:name_4 | text:@local.spend_time_idea_4",
-              "matchedExpression": "@local.spend_time_idea_4",
-              "type": "local",
-              "fieldName": "spend_time_idea_4"
-            }
-          ],
-          "4": [
-            {
-              "fullExpression": "name:name_5 | text:@local.spend_time_idea_5",
-              "matchedExpression": "@local.spend_time_idea_5",
-              "type": "local",
-              "fieldName": "spend_time_idea_5"
-            }
-          ],
-          "5": [
-            {
-              "fullExpression": "name:name_6 | text:@local.spend_time_idea_6",
-              "matchedExpression": "@local.spend_time_idea_6",
-              "type": "local",
-              "fieldName": "spend_time_idea_6"
-            }
-          ],
-          "6": [
-            {
-              "fullExpression": "name:name_7 | text:@local.spend_time_idea_7",
-              "matchedExpression": "@local.spend_time_idea_7",
-              "type": "local",
-              "fieldName": "spend_time_idea_7"
-            }
-          ],
-          "7": [
-            {
-              "fullExpression": "name:name_8 | text:@local.spend_time_idea_8",
-              "matchedExpression": "@local.spend_time_idea_8",
-              "type": "local",
-              "fieldName": "spend_time_idea_8"
-            }
-          ],
-          "8": [
-            {
-              "fullExpression": "name:name_9 | text:@local.spend_time_idea_9",
-              "matchedExpression": "@local.spend_time_idea_9",
-              "type": "local",
-              "fieldName": "spend_time_idea_9"
-            }
-          ],
-          "9": [
-            {
-              "fullExpression": "name:name_10 | text:@local.spend_time_idea_10",
-              "matchedExpression": "@local.spend_time_idea_10",
-              "type": "local",
-              "fieldName": "spend_time_idea_10"
-            }
-          ]
+          "0": {
+            "text": [
+              {
+                "fullExpression": "@local.spend_time_idea_1",
+                "matchedExpression": "@local.spend_time_idea_1",
+                "type": "local",
+                "fieldName": "spend_time_idea_1"
+              }
+            ]
+          },
+          "1": {
+            "text": [
+              {
+                "fullExpression": "@local.spend_time_idea_2",
+                "matchedExpression": "@local.spend_time_idea_2",
+                "type": "local",
+                "fieldName": "spend_time_idea_2"
+              }
+            ]
+          },
+          "2": {
+            "text": [
+              {
+                "fullExpression": "@local.spend_time_idea_3",
+                "matchedExpression": "@local.spend_time_idea_3",
+                "type": "local",
+                "fieldName": "spend_time_idea_3"
+              }
+            ]
+          },
+          "3": {
+            "text": [
+              {
+                "fullExpression": "@local.spend_time_idea_4",
+                "matchedExpression": "@local.spend_time_idea_4",
+                "type": "local",
+                "fieldName": "spend_time_idea_4"
+              }
+            ]
+          },
+          "4": {
+            "text": [
+              {
+                "fullExpression": "@local.spend_time_idea_5",
+                "matchedExpression": "@local.spend_time_idea_5",
+                "type": "local",
+                "fieldName": "spend_time_idea_5"
+              }
+            ]
+          },
+          "5": {
+            "text": [
+              {
+                "fullExpression": "@local.spend_time_idea_6",
+                "matchedExpression": "@local.spend_time_idea_6",
+                "type": "local",
+                "fieldName": "spend_time_idea_6"
+              }
+            ]
+          },
+          "6": {
+            "text": [
+              {
+                "fullExpression": "@local.spend_time_idea_7",
+                "matchedExpression": "@local.spend_time_idea_7",
+                "type": "local",
+                "fieldName": "spend_time_idea_7"
+              }
+            ]
+          },
+          "7": {
+            "text": [
+              {
+                "fullExpression": "@local.spend_time_idea_8",
+                "matchedExpression": "@local.spend_time_idea_8",
+                "type": "local",
+                "fieldName": "spend_time_idea_8"
+              }
+            ]
+          },
+          "8": {
+            "text": [
+              {
+                "fullExpression": "@local.spend_time_idea_9",
+                "matchedExpression": "@local.spend_time_idea_9",
+                "type": "local",
+                "fieldName": "spend_time_idea_9"
+              }
+            ]
+          },
+          "9": {
+            "text": [
+              {
+                "fullExpression": "@local.spend_time_idea_10",
+                "matchedExpression": "@local.spend_time_idea_10",
+                "type": "local",
+                "fieldName": "spend_time_idea_10"
+              }
+            ]
+          }
         }
       },
       "_dynamicDependencies": {
         "@local.spend_time_idea_1": [
-          "value.0"
+          "value.0.text"
         ],
         "@local.spend_time_idea_2": [
-          "value.1"
+          "value.1.text"
         ],
         "@local.spend_time_idea_3": [
-          "value.2"
+          "value.2.text"
         ],
         "@local.spend_time_idea_4": [
-          "value.3"
+          "value.3.text"
         ],
         "@local.spend_time_idea_5": [
-          "value.4"
+          "value.4.text"
         ],
         "@local.spend_time_idea_6": [
-          "value.5"
+          "value.5.text"
         ],
         "@local.spend_time_idea_7": [
-          "value.6"
+          "value.6.text"
         ],
         "@local.spend_time_idea_8": [
-          "value.7"
+          "value.7.text"
         ],
         "@local.spend_time_idea_9": [
-          "value.8"
+          "value.8.text"
         ],
         "@local.spend_time_idea_10": [
-          "value.9"
+          "value.9.text"
         ]
       }
     },

--- a/app_data/sheets/template/debug/debug_dashed_box.json
+++ b/app_data/sheets/template/debug/debug_dashed_box.json
@@ -28,8 +28,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "dashed_box",
-      "_nested_name": "dashed_box",
+      "name": "dashed_box_4",
+      "_nested_name": "dashed_box_4",
       "_dynamicFields": {
         "value": [
           {
@@ -52,8 +52,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "text",
-      "_nested_name": "text",
+      "name": "text_5",
+      "_nested_name": "text_5",
       "_dynamicFields": {
         "value": [
           {
@@ -76,8 +76,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "dashed_box",
-      "_nested_name": "dashed_box",
+      "name": "dashed_box_6",
+      "_nested_name": "dashed_box_6",
       "_dynamicFields": {
         "value": [
           {
@@ -100,8 +100,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "text",
-      "_nested_name": "text",
+      "name": "text_7",
+      "_nested_name": "text_7",
       "_dynamicFields": {
         "value": [
           {
@@ -124,13 +124,13 @@
       "_translations": {
         "value": {}
       },
-      "name": "title",
-      "_nested_name": "title"
+      "name": "title_8",
+      "_nested_name": "title_8"
     },
     {
       "type": "dashed_box",
-      "name": "dashed_box",
-      "_nested_name": "dashed_box"
+      "name": "dashed_box_9",
+      "_nested_name": "dashed_box_9"
     }
   ],
   "_xlsxPath": "debug_sheets/to_be_sorted/debug_dashed_box.xlsx"

--- a/app_data/sheets/template/debug/debug_data_image.json
+++ b/app_data/sheets/template/debug/debug_data_image.json
@@ -146,8 +146,8 @@
       },
       "exclude_from_translation": true,
       "type": "set_variable",
-      "name": "set_variable",
-      "_nested_name": "set_variable"
+      "name": "set_variable_8",
+      "_nested_name": "set_variable_8"
     },
     {
       "type": "tile_component",
@@ -196,8 +196,8 @@
       },
       "exclude_from_translation": true,
       "type": "set_variable",
-      "name": "set_variable",
-      "_nested_name": "set_variable"
+      "name": "set_variable_10",
+      "_nested_name": "set_variable_10"
     },
     {
       "type": "tile_component",

--- a/app_data/sheets/template/debug/debug_double_radio_group_1.json
+++ b/app_data/sheets/template/debug/debug_double_radio_group_1.json
@@ -48,9 +48,18 @@
         {
           "name": "answer_list",
           "value": [
-            "name:name_var_1 | text:First",
-            "name:name_var_2 | text:Second",
-            "name:name_var_3 | text:Third"
+            {
+              "name": "name_var_1",
+              "text": "First"
+            },
+            {
+              "name": "name_var_2",
+              "text": "Second"
+            },
+            {
+              "name": "name_var_3",
+              "text": "Third"
+            }
           ],
           "exclude_from_translation": true,
           "type": "set_variable",
@@ -78,9 +87,18 @@
         {
           "name": "answer_list",
           "value": [
-            "name:name_var_4 | text:1",
-            "name:name_var_5 | text:2",
-            "name:name_var_6 | text:3"
+            {
+              "name": "name_var_4",
+              "text": "1"
+            },
+            {
+              "name": "name_var_5",
+              "text": "2"
+            },
+            {
+              "name": "name_var_6",
+              "text": "3"
+            }
           ],
           "exclude_from_translation": true,
           "type": "set_variable",

--- a/app_data/sheets/template/debug/debug_double_radio_group_2.json
+++ b/app_data/sheets/template/debug/debug_double_radio_group_2.json
@@ -17,9 +17,18 @@
     {
       "name": "answer_list_1_list",
       "value": [
-        "name:name_var_1 | text:First",
-        "name:name_var_2 | text:Second",
-        "name:name_var_3 | text:Third"
+        {
+          "name": "name_var_1",
+          "text": "First"
+        },
+        {
+          "name": "name_var_2",
+          "text": "Second"
+        },
+        {
+          "name": "name_var_3",
+          "text": "Third"
+        }
       ],
       "exclude_from_translation": true,
       "type": "set_variable",
@@ -28,9 +37,18 @@
     {
       "name": "answer_list_2_list",
       "value": [
-        "name:name_var_1 | text:1",
-        "name:name_var_2 | text:2",
-        "name:name_var_3 | text:3"
+        {
+          "name": "name_var_1",
+          "text": "1"
+        },
+        {
+          "name": "name_var_2",
+          "text": "2"
+        },
+        {
+          "name": "name_var_3",
+          "text": "3"
+        }
       ],
       "exclude_from_translation": true,
       "type": "set_variable",
@@ -69,27 +87,26 @@
         },
         {
           "name": "answer_list",
-          "value": [
-            "@local.answer_list_1_list"
-          ],
+          "value": "@local.answer_list_1_list",
+          "_translations": {
+            "value": {}
+          },
           "exclude_from_translation": true,
           "type": "set_variable",
           "_nested_name": "debug_radio_group_1.answer_list",
           "_dynamicFields": {
-            "value": {
-              "0": [
-                {
-                  "fullExpression": "@local.answer_list_1_list",
-                  "matchedExpression": "@local.answer_list_1_list",
-                  "type": "local",
-                  "fieldName": "answer_list_1_list"
-                }
-              ]
-            }
+            "value": [
+              {
+                "fullExpression": "@local.answer_list_1_list",
+                "matchedExpression": "@local.answer_list_1_list",
+                "type": "local",
+                "fieldName": "answer_list_1_list"
+              }
+            ]
           },
           "_dynamicDependencies": {
             "@local.answer_list_1_list": [
-              "value.0"
+              "value"
             ]
           }
         }
@@ -114,27 +131,26 @@
         },
         {
           "name": "answer_list",
-          "value": [
-            "@local.answer_list_2_list"
-          ],
+          "value": "@local.answer_list_2_list",
+          "_translations": {
+            "value": {}
+          },
           "exclude_from_translation": true,
           "type": "set_variable",
           "_nested_name": "debug_radio_group_2.answer_list",
           "_dynamicFields": {
-            "value": {
-              "0": [
-                {
-                  "fullExpression": "@local.answer_list_2_list",
-                  "matchedExpression": "@local.answer_list_2_list",
-                  "type": "local",
-                  "fieldName": "answer_list_2_list"
-                }
-              ]
-            }
+            "value": [
+              {
+                "fullExpression": "@local.answer_list_2_list",
+                "matchedExpression": "@local.answer_list_2_list",
+                "type": "local",
+                "fieldName": "answer_list_2_list"
+              }
+            ]
           },
           "_dynamicDependencies": {
             "@local.answer_list_2_list": [
-              "value.0"
+              "value"
             ]
           }
         }

--- a/app_data/sheets/template/debug/debug_full_stop_after_var.json
+++ b/app_data/sheets/template/debug/debug_full_stop_after_var.json
@@ -195,8 +195,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "title",
-      "_nested_name": "title"
+      "name": "title_10",
+      "_nested_name": "title_10"
     },
     {
       "name": "dynamic_lookup",
@@ -338,8 +338,8 @@
         "value": {}
       },
       "exclude_from_translation": true,
-      "name": "title",
-      "_nested_name": "title"
+      "name": "title_17",
+      "_nested_name": "title_17"
     },
     {
       "type": "text",

--- a/app_data/sheets/template/debug/debug_lang_global_1.json
+++ b/app_data/sheets/template/debug/debug_lang_global_1.json
@@ -64,9 +64,18 @@
     {
       "name": "answer_list_1",
       "value": [
-        "name:happy | text:happy",
-        "name:ok | text:ok",
-        "name:sad | text:sad"
+        {
+          "name": "happy",
+          "text": "happy"
+        },
+        {
+          "name": "ok",
+          "text": "ok"
+        },
+        {
+          "name": "sad",
+          "text": "sad"
+        }
       ],
       "type": "set_variable",
       "_nested_name": "answer_list_1"
@@ -74,81 +83,114 @@
     {
       "name": "answer_list_2",
       "value": [
-        "name:happy | text:@global.language_global_1",
-        "name:ok | text:ok",
-        "name:sad | text:sad"
+        {
+          "name": "happy",
+          "text": "@global.language_global_1"
+        },
+        {
+          "name": "ok",
+          "text": "ok"
+        },
+        {
+          "name": "sad",
+          "text": "sad"
+        }
       ],
       "type": "set_variable",
       "_nested_name": "answer_list_2",
       "_dynamicFields": {
         "value": {
-          "0": [
-            {
-              "fullExpression": "name:happy | text:@global.language_global_1",
-              "matchedExpression": "@global.language_global_1",
-              "type": "global",
-              "fieldName": "language_global_1"
-            }
-          ]
+          "0": {
+            "text": [
+              {
+                "fullExpression": "@global.language_global_1",
+                "matchedExpression": "@global.language_global_1",
+                "type": "global",
+                "fieldName": "language_global_1"
+              }
+            ]
+          }
         }
       },
       "_dynamicDependencies": {
         "@global.language_global_1": [
-          "value.0"
+          "value.0.text"
         ]
       }
     },
     {
       "name": "answer_list_3",
       "value": [
-        "name:happy | text: Text and @global.language_global_1",
-        "name:ok | text:ok",
-        "name:sad | text:sad"
+        {
+          "name": "happy",
+          "text": "Text and @global.language_global_1"
+        },
+        {
+          "name": "ok",
+          "text": "ok"
+        },
+        {
+          "name": "sad",
+          "text": "sad"
+        }
       ],
       "type": "set_variable",
       "_nested_name": "answer_list_3",
       "_dynamicFields": {
         "value": {
-          "0": [
-            {
-              "fullExpression": "name:happy | text: Text and @global.language_global_1",
-              "matchedExpression": "@global.language_global_1",
-              "type": "global",
-              "fieldName": "language_global_1"
-            }
-          ]
+          "0": {
+            "text": [
+              {
+                "fullExpression": "Text and @global.language_global_1",
+                "matchedExpression": "@global.language_global_1",
+                "type": "global",
+                "fieldName": "language_global_1"
+              }
+            ]
+          }
         }
       },
       "_dynamicDependencies": {
         "@global.language_global_1": [
-          "value.0"
+          "value.0.text"
         ]
       }
     },
     {
       "name": "answer_list_4",
       "value": [
-        "name:happy | text: @local.text_2",
-        "name:ok | text:ok",
-        "name:sad | text:sad"
+        {
+          "name": "happy",
+          "text": "@local.text_2"
+        },
+        {
+          "name": "ok",
+          "text": "ok"
+        },
+        {
+          "name": "sad",
+          "text": "sad"
+        }
       ],
       "type": "set_variable",
       "_nested_name": "answer_list_4",
       "_dynamicFields": {
         "value": {
-          "0": [
-            {
-              "fullExpression": "name:happy | text: @local.text_2",
-              "matchedExpression": "@local.text_2",
-              "type": "local",
-              "fieldName": "text_2"
-            }
-          ]
+          "0": {
+            "text": [
+              {
+                "fullExpression": "@local.text_2",
+                "matchedExpression": "@local.text_2",
+                "type": "local",
+                "fieldName": "text_2"
+              }
+            ]
+          }
         }
       },
       "_dynamicDependencies": {
         "@local.text_2": [
-          "value.0"
+          "value.0.text"
         ]
       }
     },

--- a/app_data/sheets/template/debug/debug_markdown_links.json
+++ b/app_data/sheets/template/debug/debug_markdown_links.json
@@ -10,8 +10,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "text",
-      "_nested_name": "text"
+      "name": "text_2",
+      "_nested_name": "text_2"
     }
   ],
   "_xlsxPath": "debug_sheets/debug_text.xlsx"

--- a/app_data/sheets/template/debug/debug_nav.json
+++ b/app_data/sheets/template/debug/debug_nav.json
@@ -76,8 +76,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "title",
-      "_nested_name": "title"
+      "name": "title_5",
+      "_nested_name": "title_5"
     },
     {
       "type": "text",
@@ -154,8 +154,8 @@
           "_cleaned": "click | go_to: debug_nav_2"
         }
       ],
-      "name": "button",
-      "_nested_name": "button"
+      "name": "button_8",
+      "_nested_name": "button_8"
     },
     {
       "type": "button",
@@ -175,8 +175,8 @@
           "_cleaned": "click | set_field: debug_nav_field: 2"
         }
       ],
-      "name": "button",
-      "_nested_name": "button"
+      "name": "button_9",
+      "_nested_name": "button_9"
     }
   ],
   "_xlsxPath": "debug_sheets/to_be_sorted/debug_nav.xlsx"

--- a/app_data/sheets/template/debug/debug_nav_2.json
+++ b/app_data/sheets/template/debug/debug_nav_2.json
@@ -30,8 +30,8 @@
           "_cleaned": "click | go_to: debug_nav"
         }
       ],
-      "name": "button",
-      "_nested_name": "button"
+      "name": "button_3",
+      "_nested_name": "button_3"
     }
   ],
   "_xlsxPath": "debug_sheets/to_be_sorted/debug_nav.xlsx"

--- a/app_data/sheets/template/debug/debug_nesting_test_1_2.json
+++ b/app_data/sheets/template/debug/debug_nesting_test_1_2.json
@@ -11,8 +11,8 @@
         "value": {}
       },
       "exclude_from_translation": true,
-      "name": "text",
-      "_nested_name": "text"
+      "name": "text_2",
+      "_nested_name": "text_2"
     },
     {
       "type": "set_variable",
@@ -84,8 +84,8 @@
         "value": {}
       },
       "exclude_from_translation": true,
-      "name": "text",
-      "_nested_name": "text"
+      "name": "text_6",
+      "_nested_name": "text_6"
     },
     {
       "type": "set_variable",
@@ -158,8 +158,8 @@
         "value": {}
       },
       "exclude_from_translation": true,
-      "name": "text",
-      "_nested_name": "text"
+      "name": "text_11",
+      "_nested_name": "text_11"
     },
     {
       "type": "template",

--- a/app_data/sheets/template/debug/debug_radio_group.json
+++ b/app_data/sheets/template/debug/debug_radio_group.json
@@ -16,9 +16,18 @@
     {
       "name": "answer_list_1",
       "value": [
-        "name:name_var_1 | text:First",
-        "name:name_var_2 | text:Second",
-        "name:name_var_3 | text:Third"
+        {
+          "name": "name_var_1",
+          "text": "First"
+        },
+        {
+          "name": "name_var_2",
+          "text": "Second"
+        },
+        {
+          "name": "name_var_3",
+          "text": "Third"
+        }
       ],
       "type": "set_variable",
       "_nested_name": "answer_list_1"
@@ -26,63 +35,87 @@
     {
       "name": "answer_list_2",
       "value": [
-        "name: individual | text: @global.individual | image:@global.individual_image",
-        "name: together | text: @global.together | image:@global.together_image"
+        {
+          "name": "individual",
+          "text": "@global.individual",
+          "image": "@global.individual_image"
+        },
+        {
+          "name": "together",
+          "text": "@global.together",
+          "image": "@global.together_image"
+        }
       ],
       "type": "set_variable",
       "_nested_name": "answer_list_2",
       "_dynamicFields": {
         "value": {
-          "0": [
-            {
-              "fullExpression": "name: individual | text: @global.individual | image:@global.individual_image",
-              "matchedExpression": "@global.individual",
-              "type": "global",
-              "fieldName": "individual"
-            },
-            {
-              "fullExpression": "name: individual | text: @global.individual | image:@global.individual_image",
-              "matchedExpression": "@global.individual_image",
-              "type": "global",
-              "fieldName": "individual_image"
-            }
-          ],
-          "1": [
-            {
-              "fullExpression": "name: together | text: @global.together | image:@global.together_image",
-              "matchedExpression": "@global.together",
-              "type": "global",
-              "fieldName": "together"
-            },
-            {
-              "fullExpression": "name: together | text: @global.together | image:@global.together_image",
-              "matchedExpression": "@global.together_image",
-              "type": "global",
-              "fieldName": "together_image"
-            }
-          ]
+          "0": {
+            "text": [
+              {
+                "fullExpression": "@global.individual",
+                "matchedExpression": "@global.individual",
+                "type": "global",
+                "fieldName": "individual"
+              }
+            ],
+            "image": [
+              {
+                "fullExpression": "@global.individual_image",
+                "matchedExpression": "@global.individual_image",
+                "type": "global",
+                "fieldName": "individual_image"
+              }
+            ]
+          },
+          "1": {
+            "text": [
+              {
+                "fullExpression": "@global.together",
+                "matchedExpression": "@global.together",
+                "type": "global",
+                "fieldName": "together"
+              }
+            ],
+            "image": [
+              {
+                "fullExpression": "@global.together_image",
+                "matchedExpression": "@global.together_image",
+                "type": "global",
+                "fieldName": "together_image"
+              }
+            ]
+          }
         }
       },
       "_dynamicDependencies": {
         "@global.individual": [
-          "value.0"
+          "value.0.text"
         ],
         "@global.individual_image": [
-          "value.0"
+          "value.0.image"
         ],
         "@global.together": [
-          "value.1"
+          "value.1.text"
         ],
         "@global.together_image": [
-          "value.1"
+          "value.1.image"
         ]
       }
     },
     {
       "name": "answer_list_3",
       "value": [
-        "name: individual | text: First | image:plh_images/workshop_modes/individual/wave.svg",
-        "name: together | text: Second| image:plh_images/workshop_modes/individual/wave.svg"
+        {
+          "name": "individual",
+          "text": "First",
+          "image": "plh_images/workshop_modes/individual/wave.svg"
+        },
+        {
+          "name": "together",
+          "text": "Second",
+          "image": "plh_images/workshop_modes/individual/wave.svg"
+        }
       ],
       "type": "set_variable",
       "_nested_name": "answer_list_3"
@@ -172,7 +205,7 @@
           "_translations": {
             "value": {}
           },
-          "_nested_name": "display_group.image_1",
+          "_nested_name": "display_group_9.image_1",
           "_dynamicFields": {
             "value": [
               {
@@ -196,7 +229,7 @@
           "_translations": {
             "value": {}
           },
-          "_nested_name": "display_group.image_2",
+          "_nested_name": "display_group_9.image_2",
           "_dynamicFields": {
             "value": [
               {
@@ -214,8 +247,8 @@
           }
         }
       ],
-      "name": "display_group",
-      "_nested_name": "display_group"
+      "name": "display_group_9",
+      "_nested_name": "display_group_9"
     }
   ],
   "_xlsxPath": "debug_sheets/to_be_sorted/debug_radio_group.xlsx"

--- a/app_data/sheets/template/debug/debug_radio_group_2.json
+++ b/app_data/sheets/template/debug/debug_radio_group_2.json
@@ -16,8 +16,14 @@
     {
       "name": "answer_list",
       "value": [
-        "name:option_1 |  text: Option 1",
-        "name: option_2 | text: Option 2"
+        {
+          "name": "option_1",
+          "text": "Option 1"
+        },
+        {
+          "name": "option_2",
+          "text": "Option 2"
+        }
       ],
       "type": "set_variable",
       "_nested_name": "answer_list"

--- a/app_data/sheets/template/debug/debug_radio_group_dynamic.json
+++ b/app_data/sheets/template/debug/debug_radio_group_dynamic.json
@@ -7,8 +7,14 @@
     {
       "name": "answer_list",
       "value": [
-        "name:name_var_1 | text:First",
-        "name:name_var_2 | text:Second"
+        {
+          "name": "name_var_1",
+          "text": "First"
+        },
+        {
+          "name": "name_var_2",
+          "text": "Second"
+        }
       ],
       "exclude_from_translation": true,
       "type": "set_variable",

--- a/app_data/sheets/template/debug/debug_radio_group_image_scale.json
+++ b/app_data/sheets/template/debug/debug_radio_group_image_scale.json
@@ -95,7 +95,7 @@
             "style": "workshop_page",
             "icon_src": "@local.individual_image"
           },
-          "_nested_name": "display_group.individual_workshop",
+          "_nested_name": "display_group_7.individual_workshop",
           "_dynamicFields": {
             "parameter_list": {
               "first_line_text": [
@@ -134,7 +134,7 @@
             "style": "workshop_page",
             "icon_src": "@local.together_image"
           },
-          "_nested_name": "display_group.group_workshop",
+          "_nested_name": "display_group_7.group_workshop",
           "_dynamicFields": {
             "parameter_list": {
               "first_line_text": [
@@ -165,8 +165,8 @@
           }
         }
       ],
-      "name": "display_group",
-      "_nested_name": "display_group"
+      "name": "display_group_7",
+      "_nested_name": "display_group_7"
     },
     {
       "type": "title",
@@ -180,56 +180,72 @@
     {
       "name": "answer_list_1",
       "value": [
-        "name: individual | text: @local.individual_text | image: @local.individual_image",
-        "name: together | text: @local.together_text | image: @local.together_image"
+        {
+          "name": "individual",
+          "text": "@local.individual_text",
+          "image": "@local.individual_image"
+        },
+        {
+          "name": "together",
+          "text": "@local.together_text",
+          "image": "@local.together_image"
+        }
       ],
       "exclude_from_translation": true,
       "type": "set_variable",
       "_nested_name": "answer_list_1",
       "_dynamicFields": {
         "value": {
-          "0": [
-            {
-              "fullExpression": "name: individual | text: @local.individual_text | image: @local.individual_image",
-              "matchedExpression": "@local.individual_text",
-              "type": "local",
-              "fieldName": "individual_text"
-            },
-            {
-              "fullExpression": "name: individual | text: @local.individual_text | image: @local.individual_image",
-              "matchedExpression": "@local.individual_image",
-              "type": "local",
-              "fieldName": "individual_image"
-            }
-          ],
-          "1": [
-            {
-              "fullExpression": "name: together | text: @local.together_text | image: @local.together_image",
-              "matchedExpression": "@local.together_text",
-              "type": "local",
-              "fieldName": "together_text"
-            },
-            {
-              "fullExpression": "name: together | text: @local.together_text | image: @local.together_image",
-              "matchedExpression": "@local.together_image",
-              "type": "local",
-              "fieldName": "together_image"
-            }
-          ]
+          "0": {
+            "text": [
+              {
+                "fullExpression": "@local.individual_text",
+                "matchedExpression": "@local.individual_text",
+                "type": "local",
+                "fieldName": "individual_text"
+              }
+            ],
+            "image": [
+              {
+                "fullExpression": "@local.individual_image",
+                "matchedExpression": "@local.individual_image",
+                "type": "local",
+                "fieldName": "individual_image"
+              }
+            ]
+          },
+          "1": {
+            "text": [
+              {
+                "fullExpression": "@local.together_text",
+                "matchedExpression": "@local.together_text",
+                "type": "local",
+                "fieldName": "together_text"
+              }
+            ],
+            "image": [
+              {
+                "fullExpression": "@local.together_image",
+                "matchedExpression": "@local.together_image",
+                "type": "local",
+                "fieldName": "together_image"
+              }
+            ]
+          }
         }
       },
       "_dynamicDependencies": {
         "@local.individual_text": [
-          "value.0"
+          "value.0.text"
         ],
         "@local.individual_image": [
-          "value.0"
+          "value.0.image"
         ],
         "@local.together_text": [
-          "value.1"
+          "value.1.text"
         ],
         "@local.together_image": [
-          "value.1"
+          "value.1.image"
         ]
       }
     },

--- a/app_data/sheets/template/debug/debug_radio_group_replies.json
+++ b/app_data/sheets/template/debug/debug_radio_group_replies.json
@@ -7,8 +7,14 @@
     {
       "name": "answer_list",
       "value": [
-        "name:name_var_1 | text:First",
-        "name:name_var_2 | text:Second"
+        {
+          "name": "name_var_1",
+          "text": "First"
+        },
+        {
+          "name": "name_var_2",
+          "text": "Second"
+        }
       ],
       "exclude_from_translation": true,
       "type": "set_variable",

--- a/app_data/sheets/template/debug/debug_radio_group_size.json
+++ b/app_data/sheets/template/debug/debug_radio_group_size.json
@@ -7,8 +7,14 @@
     {
       "name": "answer_list_1",
       "value": [
-        "name:name_var_1 | text:First",
-        "name:name_var_2 | text:Second"
+        {
+          "name": "name_var_1",
+          "text": "First"
+        },
+        {
+          "name": "name_var_2",
+          "text": "Second"
+        }
       ],
       "exclude_from_translation": true,
       "type": "set_variable",
@@ -99,26 +105,34 @@
     {
       "name": "answer_list_2",
       "value": [
-        "name:name_var_1 | text:@local.long_text",
-        "name:name_var_2 | text:Second"
+        {
+          "name": "name_var_1",
+          "text": "@local.long_text"
+        },
+        {
+          "name": "name_var_2",
+          "text": "Second"
+        }
       ],
       "type": "set_variable",
       "_nested_name": "answer_list_2",
       "_dynamicFields": {
         "value": {
-          "0": [
-            {
-              "fullExpression": "name:name_var_1 | text:@local.long_text",
-              "matchedExpression": "@local.long_text",
-              "type": "local",
-              "fieldName": "long_text"
-            }
-          ]
+          "0": {
+            "text": [
+              {
+                "fullExpression": "@local.long_text",
+                "matchedExpression": "@local.long_text",
+                "type": "local",
+                "fieldName": "long_text"
+              }
+            ]
+          }
         }
       },
       "_dynamicDependencies": {
         "@local.long_text": [
-          "value.0"
+          "value.0.text"
         ]
       }
     },

--- a/app_data/sheets/template/debug/debug_radio_group_variables.json
+++ b/app_data/sheets/template/debug/debug_radio_group_variables.json
@@ -37,8 +37,14 @@
     {
       "name": "answer_1_list",
       "value": [
-        "name:name_1 | text:Text 1",
-        "name:name_2 | text: Text 2"
+        {
+          "name": "name_1",
+          "text": "Text 1"
+        },
+        {
+          "name": "name_2",
+          "text": "Text 2"
+        }
       ],
       "exclude_from_translation": true,
       "type": "set_variable",
@@ -47,76 +53,96 @@
     {
       "name": "answer_2_list",
       "value": [
-        "name:name_1 | text:@local.option_1",
-        "name:name_2 | text:@local.option_2"
+        {
+          "name": "name_1",
+          "text": "@local.option_1"
+        },
+        {
+          "name": "name_2",
+          "text": "@local.option_2"
+        }
       ],
       "exclude_from_translation": true,
       "type": "set_variable",
       "_nested_name": "answer_2_list",
       "_dynamicFields": {
         "value": {
-          "0": [
-            {
-              "fullExpression": "name:name_1 | text:@local.option_1",
-              "matchedExpression": "@local.option_1",
-              "type": "local",
-              "fieldName": "option_1"
-            }
-          ],
-          "1": [
-            {
-              "fullExpression": "name:name_2 | text:@local.option_2",
-              "matchedExpression": "@local.option_2",
-              "type": "local",
-              "fieldName": "option_2"
-            }
-          ]
+          "0": {
+            "text": [
+              {
+                "fullExpression": "@local.option_1",
+                "matchedExpression": "@local.option_1",
+                "type": "local",
+                "fieldName": "option_1"
+              }
+            ]
+          },
+          "1": {
+            "text": [
+              {
+                "fullExpression": "@local.option_2",
+                "matchedExpression": "@local.option_2",
+                "type": "local",
+                "fieldName": "option_2"
+              }
+            ]
+          }
         }
       },
       "_dynamicDependencies": {
         "@local.option_1": [
-          "value.0"
+          "value.0.text"
         ],
         "@local.option_2": [
-          "value.1"
+          "value.1.text"
         ]
       }
     },
     {
       "name": "answer_3_list",
       "value": [
-        "name:name_1 | text:@global.example_global_constant_text",
-        "name:name_2 | text:@global.example_global_constant_title"
+        {
+          "name": "name_1",
+          "text": "@global.example_global_constant_text"
+        },
+        {
+          "name": "name_2",
+          "text": "@global.example_global_constant_title"
+        }
       ],
       "exclude_from_translation": true,
       "type": "set_variable",
       "_nested_name": "answer_3_list",
       "_dynamicFields": {
         "value": {
-          "0": [
-            {
-              "fullExpression": "name:name_1 | text:@global.example_global_constant_text",
-              "matchedExpression": "@global.example_global_constant_text",
-              "type": "global",
-              "fieldName": "example_global_constant_text"
-            }
-          ],
-          "1": [
-            {
-              "fullExpression": "name:name_2 | text:@global.example_global_constant_title",
-              "matchedExpression": "@global.example_global_constant_title",
-              "type": "global",
-              "fieldName": "example_global_constant_title"
-            }
-          ]
+          "0": {
+            "text": [
+              {
+                "fullExpression": "@global.example_global_constant_text",
+                "matchedExpression": "@global.example_global_constant_text",
+                "type": "global",
+                "fieldName": "example_global_constant_text"
+              }
+            ]
+          },
+          "1": {
+            "text": [
+              {
+                "fullExpression": "@global.example_global_constant_title",
+                "matchedExpression": "@global.example_global_constant_title",
+                "type": "global",
+                "fieldName": "example_global_constant_title"
+              }
+            ]
+          }
         }
       },
       "_dynamicDependencies": {
         "@global.example_global_constant_text": [
-          "value.0"
+          "value.0.text"
         ],
         "@global.example_global_constant_title": [
-          "value.1"
+          "value.1.text"
         ]
       }
     },

--- a/app_data/sheets/template/debug/debug_remote_assets.json
+++ b/app_data/sheets/template/debug/debug_remote_assets.json
@@ -49,8 +49,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "title",
-      "_nested_name": "title"
+      "name": "title_4",
+      "_nested_name": "title_4"
     },
     {
       "type": "image",
@@ -58,8 +58,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "image",
-      "_nested_name": "image"
+      "name": "image_5",
+      "_nested_name": "image_5"
     },
     {
       "type": "title",
@@ -67,8 +67,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "title",
-      "_nested_name": "title"
+      "name": "title_6",
+      "_nested_name": "title_6"
     },
     {
       "type": "image",
@@ -76,8 +76,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "image",
-      "_nested_name": "image"
+      "name": "image_7",
+      "_nested_name": "image_7"
     },
     {
       "type": "button",

--- a/app_data/sheets/template/debug/debug_render_grandchild_1.json
+++ b/app_data/sheets/template/debug/debug_render_grandchild_1.json
@@ -17,8 +17,14 @@
     {
       "name": "answer_list_1",
       "value": [
-        "name: yes | text: Yes",
-        "name: no | text: No"
+        {
+          "name": "yes",
+          "text": "Yes"
+        },
+        {
+          "name": "no",
+          "text": "No"
+        }
       ],
       "exclude_from_translation": true,
       "type": "set_variable",

--- a/app_data/sheets/template/debug/debug_render_updates.json
+++ b/app_data/sheets/template/debug/debug_render_updates.json
@@ -11,8 +11,8 @@
         "value": {}
       },
       "exclude_from_translation": true,
-      "name": "title",
-      "_nested_name": "title"
+      "name": "title_2",
+      "_nested_name": "title_2"
     },
     {
       "type": "text",
@@ -21,8 +21,8 @@
         "value": {}
       },
       "exclude_from_translation": true,
-      "name": "text",
-      "_nested_name": "text"
+      "name": "text_3",
+      "_nested_name": "text_3"
     },
     {
       "type": "text",
@@ -31,8 +31,8 @@
         "value": {}
       },
       "exclude_from_translation": true,
-      "name": "text",
-      "_nested_name": "text",
+      "name": "text_4",
+      "_nested_name": "text_4",
       "_dynamicFields": {
         "value": [
           {

--- a/app_data/sheets/template/debug/debug_render_updates_child_1.json
+++ b/app_data/sheets/template/debug/debug_render_updates_child_1.json
@@ -11,8 +11,8 @@
         "value": {}
       },
       "exclude_from_translation": true,
-      "name": "title",
-      "_nested_name": "title"
+      "name": "title_2",
+      "_nested_name": "title_2"
     },
     {
       "type": "text_box",

--- a/app_data/sheets/template/debug/debug_render_updates_child_2.json
+++ b/app_data/sheets/template/debug/debug_render_updates_child_2.json
@@ -11,8 +11,8 @@
         "value": {}
       },
       "exclude_from_translation": true,
-      "name": "title",
-      "_nested_name": "title"
+      "name": "title_2",
+      "_nested_name": "title_2"
     },
     {
       "type": "text",
@@ -21,8 +21,8 @@
         "value": {}
       },
       "exclude_from_translation": true,
-      "name": "text",
-      "_nested_name": "text",
+      "name": "text_3",
+      "_nested_name": "text_3",
       "_dynamicFields": {
         "value": [
           {

--- a/app_data/sheets/template/debug/debug_set_field_triggered.json
+++ b/app_data/sheets/template/debug/debug_set_field_triggered.json
@@ -72,8 +72,8 @@
         "value": {}
       },
       "exclude_from_translation": true,
-      "name": "text",
-      "_nested_name": "text",
+      "name": "text_3",
+      "_nested_name": "text_3",
       "_dynamicFields": {
         "value": [
           {

--- a/app_data/sheets/template/debug/debug_skin_select.json
+++ b/app_data/sheets/template/debug/debug_skin_select.json
@@ -11,14 +11,20 @@
         "value": {}
       },
       "exclude_from_translation": true,
-      "name": "title",
-      "_nested_name": "title"
+      "name": "title_2",
+      "_nested_name": "title_2"
     },
     {
       "name": "skins_list",
       "value": [
-        "name: default | text: Default",
-        "name: debug | text: Debug"
+        {
+          "name": "default",
+          "text": "Default"
+        },
+        {
+          "name": "debug",
+          "text": "Debug"
+        }
       ],
       "exclude_from_translation": true,
       "type": "set_variable",

--- a/app_data/sheets/template/debug/debug_teen_ages.json
+++ b/app_data/sheets/template/debug/debug_teen_ages.json
@@ -298,7 +298,7 @@
               "_translations": {
                 "value": {}
               },
-              "_nested_name": "items.dg_sect_{@item.id}.text_age_{@item.id}",
+              "_nested_name": "items_13.dg_sect_{@item.id}.text_age_{@item.id}",
               "_dynamicFields": {
                 "name": [
                   {
@@ -318,13 +318,13 @@
                 ],
                 "_nested_name": [
                   {
-                    "fullExpression": "items.dg_sect_{@item.id}.text_age_{@item.id}",
+                    "fullExpression": "items_13.dg_sect_{@item.id}.text_age_{@item.id}",
                     "matchedExpression": "@item.id",
                     "type": "item",
                     "fieldName": "id"
                   },
                   {
-                    "fullExpression": "items.dg_sect_{@item.id}.text_age_{@item.id}",
+                    "fullExpression": "items_13.dg_sect_{@item.id}.text_age_{@item.id}",
                     "matchedExpression": "@item.id",
                     "type": "item",
                     "fieldName": "id"
@@ -364,7 +364,7 @@
                 "placeholder": "@global.tap_and_type",
                 "number_input": "true"
               },
-              "_nested_name": "items.dg_sect_{@item.id}.number_box_{@item.id}",
+              "_nested_name": "items_13.dg_sect_{@item.id}.number_box_{@item.id}",
               "_dynamicFields": {
                 "name": [
                   {
@@ -424,13 +424,13 @@
                 },
                 "_nested_name": [
                   {
-                    "fullExpression": "items.dg_sect_{@item.id}.number_box_{@item.id}",
+                    "fullExpression": "items_13.dg_sect_{@item.id}.number_box_{@item.id}",
                     "matchedExpression": "@item.id",
                     "type": "item",
                     "fieldName": "id"
                   },
                   {
-                    "fullExpression": "items.dg_sect_{@item.id}.number_box_{@item.id}",
+                    "fullExpression": "items_13.dg_sect_{@item.id}.number_box_{@item.id}",
                     "matchedExpression": "@item.id",
                     "type": "item",
                     "fieldName": "id"
@@ -455,7 +455,7 @@
               }
             }
           ],
-          "_nested_name": "items.dg_sect_{@item.id}",
+          "_nested_name": "items_13.dg_sect_{@item.id}",
           "_dynamicFields": {
             "name": [
               {
@@ -487,7 +487,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "items.dg_sect_{@item.id}",
+                "fullExpression": "items_13.dg_sect_{@item.id}",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -507,8 +507,8 @@
           }
         }
       ],
-      "name": "items",
-      "_nested_name": "items",
+      "name": "items_13",
+      "_nested_name": "items_13",
       "_dynamicFields": {
         "value": [
           {

--- a/app_data/sheets/template/debug/debug_text_line_break.json
+++ b/app_data/sheets/template/debug/debug_text_line_break.json
@@ -40,25 +40,24 @@
     {
       "type": "text",
       "name": "text_list",
-      "value": [
-        "- First bullet point\nSentence following a single line break.\n- Second bullet point.\n\nSentence following a double line break...\n- Third bullet point with text set through variable. @local.my_text"
-      ],
+      "value": "- First bullet point\nSentence following a single line break.\n- Second bullet point.\n\nSentence following a double line break...\n- Third bullet point with text set through variable. @local.my_text",
+      "_translations": {
+        "value": {}
+      },
       "_nested_name": "text_list",
       "_dynamicFields": {
-        "value": {
-          "0": [
-            {
-              "fullExpression": "- First bullet point\nSentence following a single line break.\n- Second bullet point.\n\nSentence following a double line break...\n- Third bullet point with text set through variable. @local.my_text",
-              "matchedExpression": "@local.my_text",
-              "type": "local",
-              "fieldName": "my_text"
-            }
-          ]
-        }
+        "value": [
+          {
+            "fullExpression": "- First bullet point\nSentence following a single line break.\n- Second bullet point.\n\nSentence following a double line break...\n- Third bullet point with text set through variable. @local.my_text",
+            "matchedExpression": "@local.my_text",
+            "type": "local",
+            "fieldName": "my_text"
+          }
+        ]
       },
       "_dynamicDependencies": {
         "@local.my_text": [
-          "value.0"
+          "value"
         ]
       }
     }

--- a/app_data/sheets/template/debug/debug_text_style_list.json
+++ b/app_data/sheets/template/debug/debug_text_style_list.json
@@ -13,8 +13,8 @@
       "style_list": [
         "color: red"
       ],
-      "name": "text",
-      "_nested_name": "text"
+      "name": "text_2",
+      "_nested_name": "text_2"
     },
     {
       "type": "display_group",
@@ -25,8 +25,8 @@
           "_translations": {
             "value": {}
           },
-          "name": "text",
-          "_nested_name": "display_group.text"
+          "name": "text_1",
+          "_nested_name": "display_group_3.text_1"
         },
         {
           "type": "text",
@@ -34,8 +34,8 @@
           "_translations": {
             "value": {}
           },
-          "name": "text",
-          "_nested_name": "display_group.text"
+          "name": "text_2",
+          "_nested_name": "display_group_3.text_2"
         },
         {
           "type": "text",
@@ -46,12 +46,12 @@
           "style_list": [
             "flex: 2"
           ],
-          "name": "text",
-          "_nested_name": "display_group.text"
+          "name": "text_3",
+          "_nested_name": "display_group_3.text_3"
         }
       ],
-      "name": "display_group",
-      "_nested_name": "display_group"
+      "name": "display_group_3",
+      "_nested_name": "display_group_3"
     }
   ],
   "_xlsxPath": "debug_sheets/debug_text.xlsx"

--- a/app_data/sheets/template/debug/debug_theme_language_assets.json
+++ b/app_data/sheets/template/debug/debug_theme_language_assets.json
@@ -10,8 +10,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "subtitle",
-      "_nested_name": "subtitle"
+      "name": "subtitle_2",
+      "_nested_name": "subtitle_2"
     },
     {
       "type": "image",
@@ -19,8 +19,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "image",
-      "_nested_name": "image"
+      "name": "image_3",
+      "_nested_name": "image_3"
     },
     {
       "type": "subtitle",
@@ -28,14 +28,20 @@
       "_translations": {
         "value": {}
       },
-      "name": "subtitle",
-      "_nested_name": "subtitle"
+      "name": "subtitle_4",
+      "_nested_name": "subtitle_4"
     },
     {
       "name": "theme_list",
       "value": [
-        "name: default | text: default",
-        "name: professional | text: professional"
+        {
+          "name": "default",
+          "text": "default"
+        },
+        {
+          "name": "professional",
+          "text": "professional"
+        }
       ],
       "type": "set_variable",
       "_nested_name": "theme_list"
@@ -132,8 +138,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "subtitle",
-      "_nested_name": "subtitle"
+      "name": "subtitle_7",
+      "_nested_name": "subtitle_7"
     },
     {
       "name": "language_select_options",

--- a/app_data/sheets/template/debug/debug_translation_radio_group.json
+++ b/app_data/sheets/template/debug/debug_translation_radio_group.json
@@ -70,38 +70,48 @@
     {
       "name": "answer_list_1",
       "value": [
-        "name: individual | text: @global.individual",
-        "name: together | text: @global.together"
+        {
+          "name": "individual",
+          "text": "@global.individual"
+        },
+        {
+          "name": "together",
+          "text": "@global.together"
+        }
       ],
       "exclude_from_translation": true,
       "type": "set_variable",
       "_nested_name": "answer_list_1",
       "_dynamicFields": {
         "value": {
-          "0": [
-            {
-              "fullExpression": "name: individual | text: @global.individual",
-              "matchedExpression": "@global.individual",
-              "type": "global",
-              "fieldName": "individual"
-            }
-          ],
-          "1": [
-            {
-              "fullExpression": "name: together | text: @global.together",
-              "matchedExpression": "@global.together",
-              "type": "global",
-              "fieldName": "together"
-            }
-          ]
+          "0": {
+            "text": [
+              {
+                "fullExpression": "@global.individual",
+                "matchedExpression": "@global.individual",
+                "type": "global",
+                "fieldName": "individual"
+              }
+            ]
+          },
+          "1": {
+            "text": [
+              {
+                "fullExpression": "@global.together",
+                "matchedExpression": "@global.together",
+                "type": "global",
+                "fieldName": "together"
+              }
+            ]
+          }
         }
       },
       "_dynamicDependencies": {
         "@global.individual": [
-          "value.0"
+          "value.0.text"
         ],
         "@global.together": [
-          "value.1"
+          "value.1.text"
         ]
       }
     },
@@ -195,38 +205,48 @@
     {
       "name": "answer_list_2",
       "value": [
-        "name: individual | text: @local.individual",
-        "name: together | text: @local.together"
+        {
+          "name": "individual",
+          "text": "@local.individual"
+        },
+        {
+          "name": "together",
+          "text": "@local.together"
+        }
       ],
       "exclude_from_translation": true,
       "type": "set_variable",
       "_nested_name": "answer_list_2",
       "_dynamicFields": {
         "value": {
-          "0": [
-            {
-              "fullExpression": "name: individual | text: @local.individual",
-              "matchedExpression": "@local.individual",
-              "type": "local",
-              "fieldName": "individual"
-            }
-          ],
-          "1": [
-            {
-              "fullExpression": "name: together | text: @local.together",
-              "matchedExpression": "@local.together",
-              "type": "local",
-              "fieldName": "together"
-            }
-          ]
+          "0": {
+            "text": [
+              {
+                "fullExpression": "@local.individual",
+                "matchedExpression": "@local.individual",
+                "type": "local",
+                "fieldName": "individual"
+              }
+            ]
+          },
+          "1": {
+            "text": [
+              {
+                "fullExpression": "@local.together",
+                "matchedExpression": "@local.together",
+                "type": "local",
+                "fieldName": "together"
+              }
+            ]
+          }
         }
       },
       "_dynamicDependencies": {
         "@local.individual": [
-          "value.0"
+          "value.0.text"
         ],
         "@local.together": [
-          "value.1"
+          "value.1.text"
         ]
       }
     },

--- a/app_data/sheets/template/debug/debug_update_child_1.json
+++ b/app_data/sheets/template/debug/debug_update_child_1.json
@@ -16,8 +16,14 @@
     {
       "name": "answer_list",
       "value": [
-        "name:option_1 |  text: Option 1",
-        "name: option_2 | text: Option 2"
+        {
+          "name": "option_1",
+          "text": "Option 1"
+        },
+        {
+          "name": "option_2",
+          "text": "Option 2"
+        }
       ],
       "type": "set_variable",
       "_nested_name": "answer_list"

--- a/app_data/sheets/template/debug/debug_update_child_2_a.json
+++ b/app_data/sheets/template/debug/debug_update_child_2_a.json
@@ -16,8 +16,14 @@
     {
       "name": "answer_list",
       "value": [
-        "name:option_1 |  text: Option 1",
-        "name: option_2 | text: Option 2"
+        {
+          "name": "option_1",
+          "text": "Option 1"
+        },
+        {
+          "name": "option_2",
+          "text": "Option 2"
+        }
       ],
       "type": "set_variable",
       "_nested_name": "answer_list"

--- a/app_data/sheets/template/debug/debug_variable_type.json
+++ b/app_data/sheets/template/debug/debug_variable_type.json
@@ -206,52 +206,50 @@
     {
       "type": "set_variable",
       "name": "var_list_1",
-      "value": [
-        "@data.debug_vars.list_1.value_list"
-      ],
+      "value": "@data.debug_vars.list_1.value_list",
+      "_translations": {
+        "value": {}
+      },
       "exclude_from_translation": true,
       "_nested_name": "var_list_1",
       "_dynamicFields": {
-        "value": {
-          "0": [
-            {
-              "fullExpression": "@data.debug_vars.list_1.value_list",
-              "matchedExpression": "@data.debug_vars.list_1.value_list",
-              "type": "data",
-              "fieldName": "debug_vars"
-            }
-          ]
-        }
+        "value": [
+          {
+            "fullExpression": "@data.debug_vars.list_1.value_list",
+            "matchedExpression": "@data.debug_vars.list_1.value_list",
+            "type": "data",
+            "fieldName": "debug_vars"
+          }
+        ]
       },
       "_dynamicDependencies": {
         "@data.debug_vars.list_1.value_list": [
-          "value.0"
+          "value"
         ]
       }
     },
     {
       "type": "set_variable",
       "name": "var_list_1_length",
-      "value": [
-        "@local.var_list_1.length"
-      ],
+      "value": "@local.var_list_1.length",
+      "_translations": {
+        "value": {}
+      },
       "exclude_from_translation": true,
       "_nested_name": "var_list_1_length",
       "_dynamicFields": {
-        "value": {
-          "0": [
-            {
-              "fullExpression": "@local.var_list_1.length",
-              "matchedExpression": "@local.var_list_1.length",
-              "type": "local",
-              "fieldName": "var_list_1"
-            }
-          ]
-        }
+        "value": [
+          {
+            "fullExpression": "@local.var_list_1.length",
+            "matchedExpression": "@local.var_list_1.length",
+            "type": "local",
+            "fieldName": "var_list_1"
+          }
+        ]
       },
       "_dynamicDependencies": {
         "@local.var_list_1.length": [
-          "value.0"
+          "value"
         ]
       }
     },

--- a/app_data/sheets/template/debug/example_answer_data.json
+++ b/app_data/sheets/template/debug/example_answer_data.json
@@ -151,9 +151,10 @@
     },
     {
       "name": "answer_list_data",
-      "value": [
-        "example_items_radio"
-      ],
+      "value": "example_items_radio",
+      "_translations": {
+        "value": {}
+      },
       "type": "set_variable",
       "_nested_name": "answer_list_data"
     },
@@ -298,9 +299,18 @@
     {
       "name": "answer_list",
       "value": [
-        "name: item_1 | text: first",
-        "name: item_2 | text: second",
-        "name: item_3 | text: third"
+        {
+          "name": "item_1",
+          "text": "first"
+        },
+        {
+          "name": "item_2",
+          "text": "second"
+        },
+        {
+          "name": "item_3",
+          "text": "third"
+        }
       ],
       "type": "set_variable",
       "_nested_name": "answer_list"

--- a/app_data/sheets/template/debug/example_calc_split.json
+++ b/app_data/sheets/template/debug/example_calc_split.json
@@ -555,9 +555,18 @@
     {
       "name": "answer_list",
       "value": [
-        "name: person_1 | text: person_1",
-        "name: person_2 | text: person_2",
-        "name: person_3 | text: person_3"
+        {
+          "name": "person_1",
+          "text": "person_1"
+        },
+        {
+          "name": "person_2",
+          "text": "person_2"
+        },
+        {
+          "name": "person_3",
+          "text": "person_3"
+        }
       ],
       "type": "set_variable",
       "_nested_name": "answer_list"

--- a/app_data/sheets/template/debug/example_calc_substring.json
+++ b/app_data/sheets/template/debug/example_calc_substring.json
@@ -640,26 +640,25 @@
     },
     {
       "name": "some_data_list",
-      "value": [
-        "@data.example_calc.example_2.value_list"
-      ],
+      "value": "@data.example_calc.example_2.value_list",
+      "_translations": {
+        "value": {}
+      },
       "type": "set_variable",
       "_nested_name": "some_data_list",
       "_dynamicFields": {
-        "value": {
-          "0": [
-            {
-              "fullExpression": "@data.example_calc.example_2.value_list",
-              "matchedExpression": "@data.example_calc.example_2.value_list",
-              "type": "data",
-              "fieldName": "example_calc"
-            }
-          ]
-        }
+        "value": [
+          {
+            "fullExpression": "@data.example_calc.example_2.value_list",
+            "matchedExpression": "@data.example_calc.example_2.value_list",
+            "type": "data",
+            "fieldName": "example_calc"
+          }
+        ]
       },
       "_dynamicDependencies": {
         "@data.example_calc.example_2.value_list": [
-          "value.0"
+          "value"
         ]
       }
     },
@@ -1061,26 +1060,25 @@
     },
     {
       "name": "some_data_list",
-      "value": [
-        "@data.example_calc.example_2.value"
-      ],
+      "value": "@data.example_calc.example_2.value",
+      "_translations": {
+        "value": {}
+      },
       "type": "set_variable",
       "_nested_name": "some_data_list",
       "_dynamicFields": {
-        "value": {
-          "0": [
-            {
-              "fullExpression": "@data.example_calc.example_2.value",
-              "matchedExpression": "@data.example_calc.example_2.value",
-              "type": "data",
-              "fieldName": "example_calc"
-            }
-          ]
-        }
+        "value": [
+          {
+            "fullExpression": "@data.example_calc.example_2.value",
+            "matchedExpression": "@data.example_calc.example_2.value",
+            "type": "data",
+            "fieldName": "example_calc"
+          }
+        ]
       },
       "_dynamicDependencies": {
         "@data.example_calc.example_2.value": [
-          "value.0"
+          "value"
         ]
       }
     },

--- a/app_data/sheets/template/debug/example_changed_action.json
+++ b/app_data/sheets/template/debug/example_changed_action.json
@@ -58,10 +58,22 @@
     {
       "name": "answer_list_2",
       "value": [
-        "name:name_var_1 | text:First",
-        "name:name_var_2 | text:Second",
-        "name:name_var_3 | text:Third",
-        "name:name_var_4 | text:Fourth"
+        {
+          "name": "name_var_1",
+          "text": "First"
+        },
+        {
+          "name": "name_var_2",
+          "text": "Second"
+        },
+        {
+          "name": "name_var_3",
+          "text": "Third"
+        },
+        {
+          "name": "name_var_4",
+          "text": "Fourth"
+        }
       ],
       "exclude_from_translation": true,
       "type": "set_variable",

--- a/app_data/sheets/template/debug/example_condition_bottom.json
+++ b/app_data/sheets/template/debug/example_condition_bottom.json
@@ -7,9 +7,18 @@
     {
       "name": "answer_list",
       "value": [
-        "name:name_var_1 | text:First",
-        "name:name_var_2 | text:Second",
-        "name:name_var_3 | text:Third"
+        {
+          "name": "name_var_1",
+          "text": "First"
+        },
+        {
+          "name": "name_var_2",
+          "text": "Second"
+        },
+        {
+          "name": "name_var_3",
+          "text": "Third"
+        }
       ],
       "exclude_from_translation": true,
       "type": "set_variable",

--- a/app_data/sheets/template/debug/example_go_to_1.json
+++ b/app_data/sheets/template/debug/example_go_to_1.json
@@ -7,8 +7,8 @@
     {
       "exclude_from_translation": true,
       "type": "set_variable",
-      "name": "set_variable",
-      "_nested_name": "set_variable"
+      "name": "set_variable_2",
+      "_nested_name": "set_variable_2"
     },
     {
       "type": "text",

--- a/app_data/sheets/template/debug/example_items.json
+++ b/app_data/sheets/template/debug/example_items.json
@@ -27,7 +27,7 @@
           "_translations": {
             "value": {}
           },
-          "_nested_name": "items.item_text_1_@item.id",
+          "_nested_name": "items_3.item_text_1_@item.id",
           "_dynamicFields": {
             "name": [
               {
@@ -47,7 +47,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "items.item_text_1_@item.id",
+                "fullExpression": "items_3.item_text_1_@item.id",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -69,7 +69,7 @@
           "_translations": {
             "value": {}
           },
-          "_nested_name": "items.item_text_2_@item.id",
+          "_nested_name": "items_3.item_text_2_@item.id",
           "_dynamicFields": {
             "name": [
               {
@@ -89,7 +89,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "items.item_text_2_@item.id",
+                "fullExpression": "items_3.item_text_2_@item.id",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -113,7 +113,7 @@
           "_translations": {
             "value": {}
           },
-          "_nested_name": "items.item_text_3_@item.id",
+          "_nested_name": "items_3.item_text_3_@item.id",
           "_dynamicFields": {
             "name": [
               {
@@ -133,7 +133,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "items.item_text_3_@item.id",
+                "fullExpression": "items_3.item_text_3_@item.id",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -151,8 +151,8 @@
           }
         }
       ],
-      "name": "items",
-      "_nested_name": "items",
+      "name": "items_3",
+      "_nested_name": "items_3",
       "_dynamicFields": {
         "value": [
           {
@@ -190,7 +190,7 @@
             "value": {}
           },
           "condition": "@item.field_value > 2",
-          "_nested_name": "items.example_items_field_@item.id",
+          "_nested_name": "items_6.example_items_field_@item.id",
           "_dynamicFields": {
             "name": [
               {
@@ -218,7 +218,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "items.example_items_field_@item.id",
+                "fullExpression": "items_6.example_items_field_@item.id",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -237,8 +237,8 @@
           }
         }
       ],
-      "name": "items",
-      "_nested_name": "items",
+      "name": "items_6",
+      "_nested_name": "items_6",
       "_dynamicFields": {
         "value": [
           {
@@ -341,7 +341,7 @@
           "_translations": {
             "value": {}
           },
-          "_nested_name": "items.item_id_@item.id",
+          "_nested_name": "items_11.item_id_@item.id",
           "_dynamicFields": {
             "name": [
               {
@@ -361,7 +361,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "items.item_id_@item.id",
+                "fullExpression": "items_11.item_id_@item.id",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -383,7 +383,7 @@
           "_translations": {
             "value": {}
           },
-          "_nested_name": "items.item_number_@item.id",
+          "_nested_name": "items_11.item_number_@item.id",
           "_dynamicFields": {
             "name": [
               {
@@ -403,7 +403,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "items.item_number_@item.id",
+                "fullExpression": "items_11.item_number_@item.id",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -421,8 +421,8 @@
           }
         }
       ],
-      "name": "items",
-      "_nested_name": "items",
+      "name": "items_11",
+      "_nested_name": "items_11",
       "_dynamicFields": {
         "value": [
           {

--- a/app_data/sheets/template/debug/example_items_nav.json
+++ b/app_data/sheets/template/debug/example_items_nav.json
@@ -27,7 +27,7 @@
             "value": {}
           },
           "type": "set_variable",
-          "_nested_name": "items.this_entry",
+          "_nested_name": "items_3.this_entry",
           "_dynamicFields": {
             "value": [
               {
@@ -52,7 +52,7 @@
           ],
           "condition": "@local.my_list",
           "type": "set_variable",
-          "_nested_name": "items.my_list",
+          "_nested_name": "items_3.my_list",
           "_dynamicFields": {
             "value": {
               "0": [
@@ -93,23 +93,22 @@
         },
         {
           "name": "my_list",
-          "value": [
-            "@local.this_entry"
-          ],
+          "value": "@local.this_entry",
+          "_translations": {
+            "value": {}
+          },
           "condition": "!@local.my_list",
           "type": "set_variable",
-          "_nested_name": "items.my_list",
+          "_nested_name": "items_3.my_list",
           "_dynamicFields": {
-            "value": {
-              "0": [
-                {
-                  "fullExpression": "@local.this_entry",
-                  "matchedExpression": "@local.this_entry",
-                  "type": "local",
-                  "fieldName": "this_entry"
-                }
-              ]
-            },
+            "value": [
+              {
+                "fullExpression": "@local.this_entry",
+                "matchedExpression": "@local.this_entry",
+                "type": "local",
+                "fieldName": "this_entry"
+              }
+            ],
             "condition": [
               {
                 "fullExpression": "!@local.my_list",
@@ -121,7 +120,7 @@
           },
           "_dynamicDependencies": {
             "@local.this_entry": [
-              "value.0"
+              "value"
             ],
             "!@local.my_list": [
               "condition"
@@ -131,31 +130,30 @@
         {
           "type": "text",
           "name": "print_list",
-          "value": [
-            "@local.my_list"
-          ],
-          "_nested_name": "items.print_list",
+          "value": "@local.my_list",
+          "_translations": {
+            "value": {}
+          },
+          "_nested_name": "items_3.print_list",
           "_dynamicFields": {
-            "value": {
-              "0": [
-                {
-                  "fullExpression": "@local.my_list",
-                  "matchedExpression": "@local.my_list",
-                  "type": "local",
-                  "fieldName": "my_list"
-                }
-              ]
-            }
+            "value": [
+              {
+                "fullExpression": "@local.my_list",
+                "matchedExpression": "@local.my_list",
+                "type": "local",
+                "fieldName": "my_list"
+              }
+            ]
           },
           "_dynamicDependencies": {
             "@local.my_list": [
-              "value.0"
+              "value"
             ]
           }
         }
       ],
-      "name": "items",
-      "_nested_name": "items",
+      "name": "items_3",
+      "_nested_name": "items_3",
       "_dynamicFields": {
         "value": [
           {
@@ -274,26 +272,25 @@
     },
     {
       "name": "template_list_3",
-      "value": [
-        "@data.example_items_nav.id_concat.template"
-      ],
+      "value": "@data.example_items_nav.id_concat.template",
+      "_translations": {
+        "value": {}
+      },
       "type": "set_variable",
       "_nested_name": "template_list_3",
       "_dynamicFields": {
-        "value": {
-          "0": [
-            {
-              "fullExpression": "@data.example_items_nav.id_concat.template",
-              "matchedExpression": "@data.example_items_nav.id_concat.template",
-              "type": "data",
-              "fieldName": "example_items_nav"
-            }
-          ]
-        }
+        "value": [
+          {
+            "fullExpression": "@data.example_items_nav.id_concat.template",
+            "matchedExpression": "@data.example_items_nav.id_concat.template",
+            "type": "data",
+            "fieldName": "example_items_nav"
+          }
+        ]
       },
       "_dynamicDependencies": {
         "@data.example_items_nav.id_concat.template": [
-          "value.0"
+          "value"
         ]
       }
     },
@@ -389,26 +386,25 @@
     },
     {
       "name": "template_list_5",
-      "value": [
-        "@data.example_items_nav"
-      ],
+      "value": "@data.example_items_nav",
+      "_translations": {
+        "value": {}
+      },
       "type": "set_variable",
       "_nested_name": "template_list_5",
       "_dynamicFields": {
-        "value": {
-          "0": [
-            {
-              "fullExpression": "@data.example_items_nav",
-              "matchedExpression": "@data.example_items_nav",
-              "type": "data",
-              "fieldName": "example_items_nav"
-            }
-          ]
-        }
+        "value": [
+          {
+            "fullExpression": "@data.example_items_nav",
+            "matchedExpression": "@data.example_items_nav",
+            "type": "data",
+            "fieldName": "example_items_nav"
+          }
+        ]
       },
       "_dynamicDependencies": {
         "@data.example_items_nav": [
-          "value.0"
+          "value"
         ]
       }
     },

--- a/app_data/sheets/template/debug/example_items_operations.json
+++ b/app_data/sheets/template/debug/example_items_operations.json
@@ -27,7 +27,7 @@
           "_translations": {
             "value": {}
           },
-          "_nested_name": "items.item_text_1_@item.id",
+          "_nested_name": "items_3.item_text_1_@item.id",
           "_dynamicFields": {
             "name": [
               {
@@ -47,7 +47,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "items.item_text_1_@item.id",
+                "fullExpression": "items_3.item_text_1_@item.id",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -69,7 +69,7 @@
           "_translations": {
             "value": {}
           },
-          "_nested_name": "items.item_text_2_@item.field_value",
+          "_nested_name": "items_3.item_text_2_@item.field_value",
           "_dynamicFields": {
             "name": [
               {
@@ -89,7 +89,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "items.item_text_2_@item.field_value",
+                "fullExpression": "items_3.item_text_2_@item.field_value",
                 "matchedExpression": "@item.field_value",
                 "type": "item",
                 "fieldName": "field_value"
@@ -105,8 +105,8 @@
           }
         }
       ],
-      "name": "items",
-      "_nested_name": "items",
+      "name": "items_3",
+      "_nested_name": "items_3",
       "_dynamicFields": {
         "value": [
           {
@@ -160,7 +160,7 @@
           "_translations": {
             "value": {}
           },
-          "_nested_name": "items.item_text_sort_id_@item.id",
+          "_nested_name": "items_6.item_text_sort_id_@item.id",
           "_dynamicFields": {
             "name": [
               {
@@ -180,7 +180,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "items.item_text_sort_id_@item.id",
+                "fullExpression": "items_6.item_text_sort_id_@item.id",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -202,7 +202,7 @@
           "_translations": {
             "value": {}
           },
-          "_nested_name": "items.item_text_sort_field_value_@item.field_value",
+          "_nested_name": "items_6.item_text_sort_field_value_@item.field_value",
           "_dynamicFields": {
             "name": [
               {
@@ -222,7 +222,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "items.item_text_sort_field_value_@item.field_value",
+                "fullExpression": "items_6.item_text_sort_field_value_@item.field_value",
                 "matchedExpression": "@item.field_value",
                 "type": "item",
                 "fieldName": "field_value"
@@ -238,8 +238,8 @@
           }
         }
       ],
-      "name": "items",
-      "_nested_name": "items",
+      "name": "items_6",
+      "_nested_name": "items_6",
       "_dynamicFields": {
         "value": [
           {
@@ -294,7 +294,7 @@
           "_translations": {
             "value": {}
           },
-          "_nested_name": "items.item_text_3_@item.id",
+          "_nested_name": "items_9.item_text_3_@item.id",
           "_dynamicFields": {
             "name": [
               {
@@ -314,7 +314,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "items.item_text_3_@item.id",
+                "fullExpression": "items_9.item_text_3_@item.id",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -336,7 +336,7 @@
           "_translations": {
             "value": {}
           },
-          "_nested_name": "items.item_text_4_@item.field_value",
+          "_nested_name": "items_9.item_text_4_@item.field_value",
           "_dynamicFields": {
             "name": [
               {
@@ -356,7 +356,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "items.item_text_4_@item.field_value",
+                "fullExpression": "items_9.item_text_4_@item.field_value",
                 "matchedExpression": "@item.field_value",
                 "type": "item",
                 "fieldName": "field_value"
@@ -372,8 +372,8 @@
           }
         }
       ],
-      "name": "items",
-      "_nested_name": "items",
+      "name": "items_9",
+      "_nested_name": "items_9",
       "_dynamicFields": {
         "value": [
           {
@@ -427,7 +427,7 @@
           "_translations": {
             "value": {}
           },
-          "_nested_name": "items.item_text_5_@item.id",
+          "_nested_name": "items_12.item_text_5_@item.id",
           "_dynamicFields": {
             "name": [
               {
@@ -447,7 +447,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "items.item_text_5_@item.id",
+                "fullExpression": "items_12.item_text_5_@item.id",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -469,7 +469,7 @@
           "_translations": {
             "value": {}
           },
-          "_nested_name": "items.item_text_6_@item.field_value",
+          "_nested_name": "items_12.item_text_6_@item.field_value",
           "_dynamicFields": {
             "name": [
               {
@@ -489,7 +489,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "items.item_text_6_@item.field_value",
+                "fullExpression": "items_12.item_text_6_@item.field_value",
                 "matchedExpression": "@item.field_value",
                 "type": "item",
                 "fieldName": "field_value"
@@ -505,8 +505,8 @@
           }
         }
       ],
-      "name": "items",
-      "_nested_name": "items",
+      "name": "items_12",
+      "_nested_name": "items_12",
       "_dynamicFields": {
         "value": [
           {
@@ -581,7 +581,7 @@
           "_translations": {
             "value": {}
           },
-          "_nested_name": "items.item_text_7_@item.id",
+          "_nested_name": "items_16.item_text_7_@item.id",
           "_dynamicFields": {
             "name": [
               {
@@ -601,7 +601,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "items.item_text_7_@item.id",
+                "fullExpression": "items_16.item_text_7_@item.id",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -623,7 +623,7 @@
           "_translations": {
             "value": {}
           },
-          "_nested_name": "items.item_text_8_@item.field_value",
+          "_nested_name": "items_16.item_text_8_@item.field_value",
           "_dynamicFields": {
             "name": [
               {
@@ -643,7 +643,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "items.item_text_8_@item.field_value",
+                "fullExpression": "items_16.item_text_8_@item.field_value",
                 "matchedExpression": "@item.field_value",
                 "type": "item",
                 "fieldName": "field_value"
@@ -659,8 +659,8 @@
           }
         }
       ],
-      "name": "items",
-      "_nested_name": "items",
+      "name": "items_16",
+      "_nested_name": "items_16",
       "_dynamicFields": {
         "value": [
           {

--- a/app_data/sheets/template/debug/example_items_pipe.json
+++ b/app_data/sheets/template/debug/example_items_pipe.json
@@ -30,7 +30,7 @@
           "_translations": {
             "value": {}
           },
-          "_nested_name": "items.item_text_1_@item.id",
+          "_nested_name": "items_3.item_text_1_@item.id",
           "_dynamicFields": {
             "name": [
               {
@@ -50,7 +50,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "items.item_text_1_@item.id",
+                "fullExpression": "items_3.item_text_1_@item.id",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -72,7 +72,7 @@
           "_translations": {
             "value": {}
           },
-          "_nested_name": "items.item_text_2_@item.id",
+          "_nested_name": "items_3.item_text_2_@item.id",
           "_dynamicFields": {
             "name": [
               {
@@ -92,7 +92,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "items.item_text_2_@item.id",
+                "fullExpression": "items_3.item_text_2_@item.id",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -116,7 +116,7 @@
           "_translations": {
             "value": {}
           },
-          "_nested_name": "items.item_text_3_@item.id",
+          "_nested_name": "items_3.item_text_3_@item.id",
           "_dynamicFields": {
             "name": [
               {
@@ -136,7 +136,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "items.item_text_3_@item.id",
+                "fullExpression": "items_3.item_text_3_@item.id",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -160,7 +160,7 @@
           "_translations": {
             "value": {}
           },
-          "_nested_name": "items.item_text_4_@item.id",
+          "_nested_name": "items_3.item_text_4_@item.id",
           "_dynamicFields": {
             "name": [
               {
@@ -180,7 +180,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "items.item_text_4_@item.id",
+                "fullExpression": "items_3.item_text_4_@item.id",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -224,7 +224,7 @@
               "_cleaned": "click | emit: force_reload"
             }
           ],
-          "_nested_name": "items.item_toggle_@item.id",
+          "_nested_name": "items_3.item_toggle_@item.id",
           "_dynamicFields": {
             "name": [
               {
@@ -266,7 +266,7 @@
             },
             "_nested_name": [
               {
-                "fullExpression": "items.item_toggle_@item.id",
+                "fullExpression": "items_3.item_toggle_@item.id",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -286,8 +286,8 @@
           }
         }
       ],
-      "name": "items",
-      "_nested_name": "items",
+      "name": "items_3",
+      "_nested_name": "items_3",
       "_dynamicFields": {
         "value": [
           {
@@ -342,7 +342,7 @@
           "_translations": {
             "value": {}
           },
-          "_nested_name": "items.item_text_1_@item.id",
+          "_nested_name": "items_6.item_text_1_@item.id",
           "_dynamicFields": {
             "name": [
               {
@@ -362,7 +362,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "items.item_text_1_@item.id",
+                "fullExpression": "items_6.item_text_1_@item.id",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -384,7 +384,7 @@
           "_translations": {
             "value": {}
           },
-          "_nested_name": "items.item_text_2_@item.id",
+          "_nested_name": "items_6.item_text_2_@item.id",
           "_dynamicFields": {
             "name": [
               {
@@ -404,7 +404,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "items.item_text_2_@item.id",
+                "fullExpression": "items_6.item_text_2_@item.id",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -428,7 +428,7 @@
           "_translations": {
             "value": {}
           },
-          "_nested_name": "items.item_text_3_@item.id",
+          "_nested_name": "items_6.item_text_3_@item.id",
           "_dynamicFields": {
             "name": [
               {
@@ -448,7 +448,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "items.item_text_3_@item.id",
+                "fullExpression": "items_6.item_text_3_@item.id",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -472,7 +472,7 @@
           "_translations": {
             "value": {}
           },
-          "_nested_name": "items.value: item_text_4_@item.id",
+          "_nested_name": "items_6.value: item_text_4_@item.id",
           "_dynamicFields": {
             "name": [
               {
@@ -492,7 +492,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "items.value: item_text_4_@item.id",
+                "fullExpression": "items_6.value: item_text_4_@item.id",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -536,7 +536,7 @@
               "_cleaned": "click | emit: force_reload"
             }
           ],
-          "_nested_name": "items.item_toggle_@item.id",
+          "_nested_name": "items_6.item_toggle_@item.id",
           "_dynamicFields": {
             "name": [
               {
@@ -578,7 +578,7 @@
             },
             "_nested_name": [
               {
-                "fullExpression": "items.item_toggle_@item.id",
+                "fullExpression": "items_6.item_toggle_@item.id",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -598,8 +598,8 @@
           }
         }
       ],
-      "name": "items",
-      "_nested_name": "items",
+      "name": "items_6",
+      "_nested_name": "items_6",
       "_dynamicFields": {
         "value": [
           {

--- a/app_data/sheets/template/debug/example_items_pipe_2.json
+++ b/app_data/sheets/template/debug/example_items_pipe_2.json
@@ -42,7 +42,7 @@
           "_translations": {
             "value": {}
           },
-          "_nested_name": "items.item_text_1_@item.id",
+          "_nested_name": "items_5.item_text_1_@item.id",
           "_dynamicFields": {
             "name": [
               {
@@ -62,7 +62,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "items.item_text_1_@item.id",
+                "fullExpression": "items_5.item_text_1_@item.id",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -84,7 +84,7 @@
           "_translations": {
             "value": {}
           },
-          "_nested_name": "items.item_text_2_@item.id",
+          "_nested_name": "items_5.item_text_2_@item.id",
           "_dynamicFields": {
             "name": [
               {
@@ -104,7 +104,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "items.item_text_2_@item.id",
+                "fullExpression": "items_5.item_text_2_@item.id",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -128,7 +128,7 @@
           "_translations": {
             "value": {}
           },
-          "_nested_name": "items.item_text_2_@item.id",
+          "_nested_name": "items_5.item_text_2_@item.id",
           "_dynamicFields": {
             "name": [
               {
@@ -148,7 +148,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "items.item_text_2_@item.id",
+                "fullExpression": "items_5.item_text_2_@item.id",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -166,8 +166,8 @@
           }
         }
       ],
-      "name": "items",
-      "_nested_name": "items",
+      "name": "items_5",
+      "_nested_name": "items_5",
       "_dynamicFields": {
         "value": [
           {
@@ -229,7 +229,7 @@
           "_translations": {
             "value": {}
           },
-          "_nested_name": "items.item_text_1_@item.id",
+          "_nested_name": "items_8.item_text_1_@item.id",
           "_dynamicFields": {
             "name": [
               {
@@ -249,7 +249,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "items.item_text_1_@item.id",
+                "fullExpression": "items_8.item_text_1_@item.id",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -271,7 +271,7 @@
           "_translations": {
             "value": {}
           },
-          "_nested_name": "items.item_text_2_@item.id",
+          "_nested_name": "items_8.item_text_2_@item.id",
           "_dynamicFields": {
             "name": [
               {
@@ -291,7 +291,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "items.item_text_2_@item.id",
+                "fullExpression": "items_8.item_text_2_@item.id",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -315,7 +315,7 @@
           "_translations": {
             "value": {}
           },
-          "_nested_name": "items.item_text_2_@item.id",
+          "_nested_name": "items_8.item_text_2_@item.id",
           "_dynamicFields": {
             "name": [
               {
@@ -335,7 +335,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "items.item_text_2_@item.id",
+                "fullExpression": "items_8.item_text_2_@item.id",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -353,8 +353,8 @@
           }
         }
       ],
-      "name": "items",
-      "_nested_name": "items",
+      "name": "items_8",
+      "_nested_name": "items_8",
       "_dynamicFields": {
         "value": [
           {
@@ -407,7 +407,7 @@
           "_translations": {
             "value": {}
           },
-          "_nested_name": "items.item_text_1_@item.id",
+          "_nested_name": "items_11.item_text_1_@item.id",
           "_dynamicFields": {
             "name": [
               {
@@ -427,7 +427,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "items.item_text_1_@item.id",
+                "fullExpression": "items_11.item_text_1_@item.id",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -449,7 +449,7 @@
           "_translations": {
             "value": {}
           },
-          "_nested_name": "items.item_text_2_@item.id",
+          "_nested_name": "items_11.item_text_2_@item.id",
           "_dynamicFields": {
             "name": [
               {
@@ -469,7 +469,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "items.item_text_2_@item.id",
+                "fullExpression": "items_11.item_text_2_@item.id",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -493,7 +493,7 @@
           "_translations": {
             "value": {}
           },
-          "_nested_name": "items.item_text_2_@item.id",
+          "_nested_name": "items_11.item_text_2_@item.id",
           "_dynamicFields": {
             "name": [
               {
@@ -513,7 +513,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "items.item_text_2_@item.id",
+                "fullExpression": "items_11.item_text_2_@item.id",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -531,8 +531,8 @@
           }
         }
       ],
-      "name": "items",
-      "_nested_name": "items",
+      "name": "items_11",
+      "_nested_name": "items_11",
       "_dynamicFields": {
         "value": [
           {
@@ -594,7 +594,7 @@
           "_translations": {
             "value": {}
           },
-          "_nested_name": "items.item_text_1_@item.id",
+          "_nested_name": "items_14.item_text_1_@item.id",
           "_dynamicFields": {
             "name": [
               {
@@ -614,7 +614,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "items.item_text_1_@item.id",
+                "fullExpression": "items_14.item_text_1_@item.id",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -636,7 +636,7 @@
           "_translations": {
             "value": {}
           },
-          "_nested_name": "items.item_text_2_@item.id",
+          "_nested_name": "items_14.item_text_2_@item.id",
           "_dynamicFields": {
             "name": [
               {
@@ -656,7 +656,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "items.item_text_2_@item.id",
+                "fullExpression": "items_14.item_text_2_@item.id",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -680,7 +680,7 @@
           "_translations": {
             "value": {}
           },
-          "_nested_name": "items.item_text_2_@item.id",
+          "_nested_name": "items_14.item_text_2_@item.id",
           "_dynamicFields": {
             "name": [
               {
@@ -700,7 +700,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "items.item_text_2_@item.id",
+                "fullExpression": "items_14.item_text_2_@item.id",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -718,8 +718,8 @@
           }
         }
       ],
-      "name": "items",
-      "_nested_name": "items",
+      "name": "items_14",
+      "_nested_name": "items_14",
       "_dynamicFields": {
         "value": [
           {

--- a/app_data/sheets/template/debug/example_items_unlock.json
+++ b/app_data/sheets/template/debug/example_items_unlock.json
@@ -72,7 +72,7 @@
           "_translations": {
             "value": {}
           },
-          "_nested_name": "items.@item.unlock_fieldname",
+          "_nested_name": "items_5.@item.unlock_fieldname",
           "_dynamicFields": {
             "name": [
               {
@@ -104,7 +104,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "items.@item.unlock_fieldname",
+                "fullExpression": "items_5.@item.unlock_fieldname",
                 "matchedExpression": "@item.unlock_fieldname",
                 "type": "item",
                 "fieldName": "unlock_fieldname"
@@ -138,7 +138,7 @@
               "_translations": {
                 "value": {}
               },
-              "_nested_name": "items.group_@item.id.text_group_item_@item.id",
+              "_nested_name": "items_5.group_@item.id.text_group_item_@item.id",
               "_dynamicFields": {
                 "name": [
                   {
@@ -158,13 +158,13 @@
                 ],
                 "_nested_name": [
                   {
-                    "fullExpression": "items.group_@item.id.text_group_item_@item.id",
+                    "fullExpression": "items_5.group_@item.id.text_group_item_@item.id",
                     "matchedExpression": "@item.id.text_group_item_",
                     "type": "item",
                     "fieldName": "id"
                   },
                   {
-                    "fullExpression": "items.group_@item.id.text_group_item_@item.id",
+                    "fullExpression": "items_5.group_@item.id.text_group_item_@item.id",
                     "matchedExpression": "@item.id",
                     "type": "item",
                     "fieldName": "id"
@@ -189,7 +189,7 @@
               "_translations": {
                 "value": {}
               },
-              "_nested_name": "items.group_@item.id.text_workshop_unlock_week_@item.id",
+              "_nested_name": "items_5.group_@item.id.text_workshop_unlock_week_@item.id",
               "_dynamicFields": {
                 "name": [
                   {
@@ -209,13 +209,13 @@
                 ],
                 "_nested_name": [
                   {
-                    "fullExpression": "items.group_@item.id.text_workshop_unlock_week_@item.id",
+                    "fullExpression": "items_5.group_@item.id.text_workshop_unlock_week_@item.id",
                     "matchedExpression": "@item.id.text_workshop_unlock_week_",
                     "type": "item",
                     "fieldName": "id"
                   },
                   {
-                    "fullExpression": "items.group_@item.id.text_workshop_unlock_week_@item.id",
+                    "fullExpression": "items_5.group_@item.id.text_workshop_unlock_week_@item.id",
                     "matchedExpression": "@item.id",
                     "type": "item",
                     "fieldName": "id"
@@ -242,7 +242,7 @@
               "_translations": {
                 "value": {}
               },
-              "_nested_name": "items.group_@item.id.text_workshop_unlocked_@item.id",
+              "_nested_name": "items_5.group_@item.id.text_workshop_unlocked_@item.id",
               "_dynamicFields": {
                 "name": [
                   {
@@ -262,13 +262,13 @@
                 ],
                 "_nested_name": [
                   {
-                    "fullExpression": "items.group_@item.id.text_workshop_unlocked_@item.id",
+                    "fullExpression": "items_5.group_@item.id.text_workshop_unlocked_@item.id",
                     "matchedExpression": "@item.id.text_workshop_unlocked_",
                     "type": "item",
                     "fieldName": "id"
                   },
                   {
-                    "fullExpression": "items.group_@item.id.text_workshop_unlocked_@item.id",
+                    "fullExpression": "items_5.group_@item.id.text_workshop_unlocked_@item.id",
                     "matchedExpression": "@item.id",
                     "type": "item",
                     "fieldName": "id"
@@ -289,7 +289,7 @@
               }
             }
           ],
-          "_nested_name": "items.group_@item.id",
+          "_nested_name": "items_5.group_@item.id",
           "_dynamicFields": {
             "name": [
               {
@@ -301,7 +301,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "items.group_@item.id",
+                "fullExpression": "items_5.group_@item.id",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -316,8 +316,8 @@
           }
         }
       ],
-      "name": "items",
-      "_nested_name": "items",
+      "name": "items_5",
+      "_nested_name": "items_5",
       "_dynamicFields": {
         "value": [
           {

--- a/app_data/sheets/template/debug/example_lang_select.json
+++ b/app_data/sheets/template/debug/example_lang_select.json
@@ -11,14 +11,20 @@
         "value": {}
       },
       "exclude_from_translation": true,
-      "name": "title",
-      "_nested_name": "title"
+      "name": "title_2",
+      "_nested_name": "title_2"
     },
     {
       "name": "language_list",
       "value": [
-        "name: za_en | text: English",
-        "name: es_sp | text: Español"
+        {
+          "name": "za_en",
+          "text": "English"
+        },
+        {
+          "name": "es_sp",
+          "text": "Español"
+        }
       ],
       "exclude_from_translation": true,
       "type": "set_variable",

--- a/app_data/sheets/template/debug/example_lang_template_1.json
+++ b/app_data/sheets/template/debug/example_lang_template_1.json
@@ -50,9 +50,21 @@
     {
       "name": "answer_list_1",
       "value": [
-        "name:happy | image:plh_images/stickers/faces/happier.svg | image_checked:plh_images/stickers/faces/happier.svg",
-        "name:ok | image:plh_images/stickers/faces/neutral.svg | image_checked:plh_images/stickers/faces/neutral.svg",
-        "name:sad | image:plh_images/stickers/faces/sadder.svg |  image_checked:plh_images/stickers/faces/sadder.svg"
+        {
+          "name": "happy",
+          "image": "plh_images/stickers/faces/happier.svg",
+          "image_checked": "plh_images/stickers/faces/happier.svg"
+        },
+        {
+          "name": "ok",
+          "image": "plh_images/stickers/faces/neutral.svg",
+          "image_checked": "plh_images/stickers/faces/neutral.svg"
+        },
+        {
+          "name": "sad",
+          "image": "plh_images/stickers/faces/sadder.svg",
+          "image_checked": "plh_images/stickers/faces/sadder.svg"
+        }
       ],
       "type": "set_variable",
       "_nested_name": "answer_list_1"
@@ -332,9 +344,18 @@
     {
       "name": "answer_list_2",
       "value": [
-        "name:happy | text:happy",
-        "name:ok | text:ok",
-        "name:sad | text:sad"
+        {
+          "name": "happy",
+          "text": "happy"
+        },
+        {
+          "name": "ok",
+          "text": "ok"
+        },
+        {
+          "name": "sad",
+          "text": "sad"
+        }
       ],
       "type": "set_variable",
       "_nested_name": "answer_list_2"
@@ -399,9 +420,18 @@
     {
       "name": "answer_list_2",
       "value": [
-        "name: option_1 | text:This is the first default option for the combo box",
-        "name: option_2 | text:This is the second default option for the combo box",
-        "name: option_3 | text:This is the third default option for the combo box"
+        {
+          "name": "option_1",
+          "text": "This is the first default option for the combo box"
+        },
+        {
+          "name": "option_2",
+          "text": "This is the second default option for the combo box"
+        },
+        {
+          "name": "option_3",
+          "text": "This is the third default option for the combo box"
+        }
       ],
       "type": "set_variable",
       "_nested_name": "answer_list_2"
@@ -801,7 +831,7 @@
             "value": {}
           },
           "exclude_from_translation": true,
-          "_nested_name": "display_group.text_6"
+          "_nested_name": "display_group_35.text_6"
         },
         {
           "type": "text",
@@ -810,7 +840,7 @@
           "_translations": {
             "value": {}
           },
-          "_nested_name": "display_group.text_7",
+          "_nested_name": "display_group_35.text_7",
           "_dynamicFields": {
             "value": [
               {
@@ -828,8 +858,8 @@
           }
         }
       ],
-      "name": "display_group",
-      "_nested_name": "display_group"
+      "name": "display_group_35",
+      "_nested_name": "display_group_35"
     },
     {
       "type": "display_group",
@@ -845,7 +875,7 @@
             "value": {}
           },
           "exclude_from_translation": true,
-          "_nested_name": "display_group.text_8"
+          "_nested_name": "display_group_37.text_8"
         },
         {
           "type": "text",
@@ -854,7 +884,7 @@
           "_translations": {
             "value": {}
           },
-          "_nested_name": "display_group.text_9",
+          "_nested_name": "display_group_37.text_9",
           "_dynamicFields": {
             "value": [
               {
@@ -872,8 +902,8 @@
           }
         }
       ],
-      "name": "display_group",
-      "_nested_name": "display_group"
+      "name": "display_group_37",
+      "_nested_name": "display_group_37"
     },
     {
       "type": "display_group",

--- a/app_data/sheets/template/debug/example_lang_template_2.json
+++ b/app_data/sheets/template/debug/example_lang_template_2.json
@@ -67,9 +67,18 @@
         {
           "name": "answer_list_2",
           "value": [
-            "name: option_1 | text:Cats (modified text in answer list)",
-            "name: option_2 | text:Dogs (modified text in answer list)",
-            "name: option_3 | text:Chinchillas (modified text in answer list)"
+            {
+              "name": "option_1",
+              "text": "Cats (modified text in answer list)"
+            },
+            {
+              "name": "option_2",
+              "text": "Dogs (modified text in answer list)"
+            },
+            {
+              "name": "option_3",
+              "text": "Chinchillas (modified text in answer list)"
+            }
           ],
           "type": "set_variable",
           "_nested_name": "example_lang_template_1.answer_list_2"

--- a/app_data/sheets/template/debug/example_multiple_locals.json
+++ b/app_data/sheets/template/debug/example_multiple_locals.json
@@ -37,50 +37,65 @@
     {
       "name": "answer_list",
       "value": [
-        "name: name_1 | text: @local.name_1",
-        "name: name_2 | text: @local.name_2",
-        "name: name_3 | text: @local.name_3"
+        {
+          "name": "name_1",
+          "text": "@local.name_1"
+        },
+        {
+          "name": "name_2",
+          "text": "@local.name_2"
+        },
+        {
+          "name": "name_3",
+          "text": "@local.name_3"
+        }
       ],
       "exclude_from_translation": true,
       "type": "set_variable",
       "_nested_name": "answer_list",
       "_dynamicFields": {
         "value": {
-          "0": [
-            {
-              "fullExpression": "name: name_1 | text: @local.name_1",
-              "matchedExpression": "@local.name_1",
-              "type": "local",
-              "fieldName": "name_1"
-            }
-          ],
-          "1": [
-            {
-              "fullExpression": "name: name_2 | text: @local.name_2",
-              "matchedExpression": "@local.name_2",
-              "type": "local",
-              "fieldName": "name_2"
-            }
-          ],
-          "2": [
-            {
-              "fullExpression": "name: name_3 | text: @local.name_3",
-              "matchedExpression": "@local.name_3",
-              "type": "local",
-              "fieldName": "name_3"
-            }
-          ]
+          "0": {
+            "text": [
+              {
+                "fullExpression": "@local.name_1",
+                "matchedExpression": "@local.name_1",
+                "type": "local",
+                "fieldName": "name_1"
+              }
+            ]
+          },
+          "1": {
+            "text": [
+              {
+                "fullExpression": "@local.name_2",
+                "matchedExpression": "@local.name_2",
+                "type": "local",
+                "fieldName": "name_2"
+              }
+            ]
+          },
+          "2": {
+            "text": [
+              {
+                "fullExpression": "@local.name_3",
+                "matchedExpression": "@local.name_3",
+                "type": "local",
+                "fieldName": "name_3"
+              }
+            ]
+          }
         }
       },
       "_dynamicDependencies": {
         "@local.name_1": [
-          "value.0"
+          "value.0.text"
         ],
         "@local.name_2": [
-          "value.1"
+          "value.1.text"
         ],
         "@local.name_3": [
-          "value.2"
+          "value.2.text"
         ]
       }
     },

--- a/app_data/sheets/template/debug/example_navigation_style.json
+++ b/app_data/sheets/template/debug/example_navigation_style.json
@@ -49,8 +49,8 @@
             "style": "navigation"
           },
           "type": "set_variable",
-          "name": "set_variable",
-          "_nested_name": "page_1.set_variable"
+          "name": "set_variable_3",
+          "_nested_name": "page_1.set_variable_3"
         },
         {
           "type": "template",

--- a/app_data/sheets/template/debug/example_navigation_style_2.json
+++ b/app_data/sheets/template/debug/example_navigation_style_2.json
@@ -50,7 +50,7 @@
             }
           ],
           "exclude_from_translation": true,
-          "_nested_name": "display_group.button_1"
+          "_nested_name": "display_group_4.button_1"
         },
         {
           "type": "button",
@@ -71,11 +71,11 @@
             }
           ],
           "exclude_from_translation": true,
-          "_nested_name": "display_group.button_2"
+          "_nested_name": "display_group_4.button_2"
         }
       ],
-      "name": "display_group",
-      "_nested_name": "display_group"
+      "name": "display_group_4",
+      "_nested_name": "display_group_4"
     },
     {
       "type": "text",

--- a/app_data/sheets/template/debug/example_nested_comp_var.json
+++ b/app_data/sheets/template/debug/example_nested_comp_var.json
@@ -19,9 +19,18 @@
             {
               "name": "answer_list",
               "value": [
-                "name:name_var_1 | text:Option a",
-                "name:name_var_2 | text: Option b",
-                "name:name_var_3 | text: Option c"
+                {
+                  "name": "name_var_1",
+                  "text": "Option a"
+                },
+                {
+                  "name": "name_var_2",
+                  "text": "Option b"
+                },
+                {
+                  "name": "name_var_3",
+                  "text": "Option c"
+                }
               ],
               "exclude_from_translation": true,
               "type": "set_variable",

--- a/app_data/sheets/template/debug/example_new_nav_buttons.json
+++ b/app_data/sheets/template/debug/example_new_nav_buttons.json
@@ -22,7 +22,7 @@
           "style_list": [
             "flex:1"
           ],
-          "_nested_name": "display_group.left"
+          "_nested_name": "display_group_2.left"
         },
         {
           "type": "text",
@@ -35,7 +35,7 @@
           "style_list": [
             "flex:4"
           ],
-          "_nested_name": "display_group.blank_text"
+          "_nested_name": "display_group_2.blank_text"
         },
         {
           "type": "text",
@@ -48,11 +48,11 @@
           "style_list": [
             "flex:1"
           ],
-          "_nested_name": "display_group.right"
+          "_nested_name": "display_group_2.right"
         }
       ],
-      "name": "display_group",
-      "_nested_name": "display_group"
+      "name": "display_group_2",
+      "_nested_name": "display_group_2"
     }
   ],
   "_xlsxPath": "example_sheets/to_be_sorted/example_new_nav_buttons.xlsx"

--- a/app_data/sheets/template/debug/example_parent_point_box_info.json
+++ b/app_data/sheets/template/debug/example_parent_point_box_info.json
@@ -10,8 +10,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "lottie_animation",
-      "_nested_name": "lottie_animation"
+      "name": "lottie_animation_2",
+      "_nested_name": "lottie_animation_2"
     },
     {
       "type": "title",
@@ -19,8 +19,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "title",
-      "_nested_name": "title"
+      "name": "title_3",
+      "_nested_name": "title_3"
     },
     {
       "type": "text",
@@ -28,8 +28,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "text",
-      "_nested_name": "text"
+      "name": "text_4",
+      "_nested_name": "text_4"
     }
   ],
   "_xlsxPath": "example_sheets/to_be_sorted/example_parent_point_box.xlsx"

--- a/app_data/sheets/template/debug/example_radio_group.json
+++ b/app_data/sheets/template/debug/example_radio_group.json
@@ -7,10 +7,30 @@
     {
       "name": "answer_list_1",
       "value": [
-        "name:name_var_1 | text:First | image:/plh_images/icons/heart.svg | image_checked: /plh_images/icons/tick.svg",
-        "name:name_var_2 | text:Second | image:/plh_images/icons/heart.svg | image_checked: /plh_images/icons/tick.svg",
-        "name:name_var_3 | text: Third | image:/plh_images/icons/heart.svg | image_checked: /plh_images/icons/tick.svg",
-        "name:name_var_4 | text:Fourth | image:/plh_images/icons/heart.svg | image_checked: /plh_images/icons/tick.svg"
+        {
+          "name": "name_var_1",
+          "text": "First",
+          "image": "/plh_images/icons/heart.svg",
+          "image_checked": "/plh_images/icons/tick.svg"
+        },
+        {
+          "name": "name_var_2",
+          "text": "Second",
+          "image": "/plh_images/icons/heart.svg",
+          "image_checked": "/plh_images/icons/tick.svg"
+        },
+        {
+          "name": "name_var_3",
+          "text": "Third",
+          "image": "/plh_images/icons/heart.svg",
+          "image_checked": "/plh_images/icons/tick.svg"
+        },
+        {
+          "name": "name_var_4",
+          "text": "Fourth",
+          "image": "/plh_images/icons/heart.svg",
+          "image_checked": "/plh_images/icons/tick.svg"
+        }
       ],
       "type": "set_variable",
       "_nested_name": "answer_list_1"

--- a/app_data/sheets/template/debug/example_radio_group_fb_con.json
+++ b/app_data/sheets/template/debug/example_radio_group_fb_con.json
@@ -7,9 +7,24 @@
     {
       "name": "answer_list_1",
       "value": [
-        "name:name_var_1 | text:First | image:/plh_images/icons/heart.svg | image_checked: /plh_images/icons/tick.svg",
-        "name:name_var_2 | text:Second | image:/plh_images/icons/heart.svg | image_checked: /plh_images/icons/tick.svg",
-        "name:name_var_3 | text: Third | image:/plh_images/icons/heart.svg | image_checked: /plh_images/icons/tick.svg"
+        {
+          "name": "name_var_1",
+          "text": "First",
+          "image": "/plh_images/icons/heart.svg",
+          "image_checked": "/plh_images/icons/tick.svg"
+        },
+        {
+          "name": "name_var_2",
+          "text": "Second",
+          "image": "/plh_images/icons/heart.svg",
+          "image_checked": "/plh_images/icons/tick.svg"
+        },
+        {
+          "name": "name_var_3",
+          "text": "Third",
+          "image": "/plh_images/icons/heart.svg",
+          "image_checked": "/plh_images/icons/tick.svg"
+        }
       ],
       "exclude_from_translation": true,
       "type": "set_variable",

--- a/app_data/sheets/template/debug/example_radio_group_fb_hid.json
+++ b/app_data/sheets/template/debug/example_radio_group_fb_hid.json
@@ -7,9 +7,24 @@
     {
       "name": "answer_list_1",
       "value": [
-        "name:name_var_1 | text:First | image:/plh_images/icons/heart.svg | image_checked: /plh_images/icons/tick.svg",
-        "name:name_var_2 | text:Second | image:/plh_images/icons/heart.svg | image_checked: /plh_images/icons/tick.svg",
-        "name:name_var_3 | text: Third | image:/plh_images/icons/heart.svg | image_checked: /plh_images/icons/tick.svg"
+        {
+          "name": "name_var_1",
+          "text": "First",
+          "image": "/plh_images/icons/heart.svg",
+          "image_checked": "/plh_images/icons/tick.svg"
+        },
+        {
+          "name": "name_var_2",
+          "text": "Second",
+          "image": "/plh_images/icons/heart.svg",
+          "image_checked": "/plh_images/icons/tick.svg"
+        },
+        {
+          "name": "name_var_3",
+          "text": "Third",
+          "image": "/plh_images/icons/heart.svg",
+          "image_checked": "/plh_images/icons/tick.svg"
+        }
       ],
       "exclude_from_translation": true,
       "type": "set_variable",

--- a/app_data/sheets/template/debug/example_task_group_stepper.json
+++ b/app_data/sheets/template/debug/example_task_group_stepper.json
@@ -24,7 +24,7 @@
             "value": {}
           },
           "type": "set_variable",
-          "_nested_name": "data_items.template_name",
+          "_nested_name": "data_items_3.template_name",
           "_dynamicFields": {
             "value": [
               {
@@ -47,7 +47,7 @@
           "value": "@local.template_name",
           "condition": "@item.active",
           "rows": [],
-          "_nested_name": "data_items.@local.template_name",
+          "_nested_name": "data_items_3.@local.template_name",
           "_dynamicFields": {
             "name": [
               {
@@ -75,7 +75,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "data_items.@local.template_name",
+                "fullExpression": "data_items_3.@local.template_name",
                 "matchedExpression": "@local.template_name",
                 "type": "local",
                 "fieldName": "template_name"
@@ -124,7 +124,7 @@
             }
           ],
           "condition": "@item.active && !@item._last",
-          "_nested_name": "data_items.nav_forwards_@item.id",
+          "_nested_name": "data_items_3.nav_forwards_@item.id",
           "_dynamicFields": {
             "name": [
               {
@@ -180,7 +180,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "data_items.nav_forwards_@item.id",
+                "fullExpression": "data_items_3.nav_forwards_@item.id",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -236,7 +236,7 @@
             }
           ],
           "condition": "@item.active && !@item._first",
-          "_nested_name": "data_items.nav_backwards_@item.id",
+          "_nested_name": "data_items_3.nav_backwards_@item.id",
           "_dynamicFields": {
             "name": [
               {
@@ -292,7 +292,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "data_items.nav_backwards_@item.id",
+                "fullExpression": "data_items_3.nav_backwards_@item.id",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -318,8 +318,8 @@
           }
         }
       ],
-      "name": "data_items",
-      "_nested_name": "data_items",
+      "name": "data_items_3",
+      "_nested_name": "data_items_3",
       "_dynamicFields": {
         "value": [
           {
@@ -333,280 +333,6 @@
       "_dynamicDependencies": {
         "@local.task_group": [
           "value"
-        ]
-      }
-    },
-    {
-      "name": "nav_forwards",
-      "action_list": [
-        {
-          "trigger": "click",
-          "action_id": "set_item",
-          "args": [],
-          "_raw": "click | set_item | completed:true",
-          "_cleaned": "click | set_item | completed:true",
-          "params": {
-            "completed": true
-          }
-        },
-        {
-          "trigger": "click",
-          "action_id": "set_active_item",
-          "args": [],
-          "_raw": "click | set_active_item | @item.index + 1",
-          "_cleaned": "click | set_active_item | @item.index + 1",
-          "params": {
-            "@item": {}
-          }
-        }
-      ],
-      "type": "set_variable",
-      "_nested_name": "nav_forwards",
-      "_dynamicFields": {
-        "action_list": {
-          "1": {
-            "_raw": [
-              {
-                "fullExpression": "click | set_active_item | @item.index + 1",
-                "matchedExpression": "@item.index",
-                "type": "item",
-                "fieldName": "index"
-              }
-            ],
-            "_cleaned": [
-              {
-                "fullExpression": "click | set_active_item | @item.index + 1",
-                "matchedExpression": "@item.index",
-                "type": "item",
-                "fieldName": "index"
-              }
-            ]
-          }
-        }
-      },
-      "_dynamicDependencies": {
-        "@item.index": [
-          "action_list.1._raw",
-          "action_list.1._cleaned"
-        ]
-      }
-    },
-    {
-      "name": "nav_backwards",
-      "action_list": [
-        {
-          "trigger": "click",
-          "action_id": "set_active_item",
-          "args": [],
-          "_raw": "click | set_active_item | @item.index - 1",
-          "_cleaned": "click | set_active_item | @item.index - 1",
-          "params": {
-            "@item": {}
-          }
-        }
-      ],
-      "type": "set_variable",
-      "_nested_name": "nav_backwards",
-      "_dynamicFields": {
-        "action_list": {
-          "0": {
-            "_raw": [
-              {
-                "fullExpression": "click | set_active_item | @item.index - 1",
-                "matchedExpression": "@item.index",
-                "type": "item",
-                "fieldName": "index"
-              }
-            ],
-            "_cleaned": [
-              {
-                "fullExpression": "click | set_active_item | @item.index - 1",
-                "matchedExpression": "@item.index",
-                "type": "item",
-                "fieldName": "index"
-              }
-            ]
-          }
-        }
-      },
-      "_dynamicDependencies": {
-        "@item.index": [
-          "action_list.0._raw",
-          "action_list.0._cleaned"
-        ]
-      }
-    },
-    {
-      "name": "nav_forwards",
-      "value": "Next",
-      "_translations": {
-        "value": {}
-      },
-      "action_list": [
-        {
-          "trigger": "click",
-          "action_id": "set_item",
-          "args": [],
-          "_raw": "click | set_item | completed:true",
-          "_cleaned": "click | set_item | completed:true",
-          "params": {
-            "completed": true
-          }
-        },
-        {
-          "trigger": "click",
-          "action_id": "set_item",
-          "args": [],
-          "_raw": "click | set_item | active:false",
-          "_cleaned": "click | set_item | active:false",
-          "params": {
-            "active": false
-          }
-        },
-        {
-          "trigger": "click",
-          "action_id": "set_item_at_index",
-          "args": [],
-          "_raw": "click | set_item_at_index | @item.index + 1 | active:true",
-          "_cleaned": "click | set_item_at_index | @item.index + 1 | active:true",
-          "params": {
-            "@item": {}
-          }
-        }
-      ],
-      "type": "set_variable",
-      "_nested_name": "nav_forwards",
-      "_dynamicFields": {
-        "action_list": {
-          "2": {
-            "_raw": [
-              {
-                "fullExpression": "click | set_item_at_index | @item.index + 1 | active:true",
-                "matchedExpression": "@item.index",
-                "type": "item",
-                "fieldName": "index"
-              }
-            ],
-            "_cleaned": [
-              {
-                "fullExpression": "click | set_item_at_index | @item.index + 1 | active:true",
-                "matchedExpression": "@item.index",
-                "type": "item",
-                "fieldName": "index"
-              }
-            ]
-          }
-        }
-      },
-      "_dynamicDependencies": {
-        "@item.index": [
-          "action_list.2._raw",
-          "action_list.2._cleaned"
-        ]
-      }
-    },
-    {
-      "name": "nav_forwards",
-      "value": "Next",
-      "_translations": {
-        "value": {}
-      },
-      "action_list": [
-        {
-          "trigger": "click",
-          "action_id": "set_item",
-          "args": [],
-          "_raw": "click | set_item | completed:true, active:false",
-          "_cleaned": "click | set_item | completed:true, active:false",
-          "params": {
-            "completed": true,
-            "active": false
-          }
-        },
-        {
-          "trigger": "click",
-          "action_id": "set_item_at_index",
-          "args": [],
-          "_raw": "click | set_item_at_index | @item.index + 1 | active:true",
-          "_cleaned": "click | set_item_at_index | @item.index + 1 | active:true",
-          "params": {
-            "@item": {}
-          }
-        }
-      ],
-      "type": "set_variable",
-      "_nested_name": "nav_forwards",
-      "_dynamicFields": {
-        "action_list": {
-          "1": {
-            "_raw": [
-              {
-                "fullExpression": "click | set_item_at_index | @item.index + 1 | active:true",
-                "matchedExpression": "@item.index",
-                "type": "item",
-                "fieldName": "index"
-              }
-            ],
-            "_cleaned": [
-              {
-                "fullExpression": "click | set_item_at_index | @item.index + 1 | active:true",
-                "matchedExpression": "@item.index",
-                "type": "item",
-                "fieldName": "index"
-              }
-            ]
-          }
-        }
-      },
-      "_dynamicDependencies": {
-        "@item.index": [
-          "action_list.1._raw",
-          "action_list.1._cleaned"
-        ]
-      }
-    },
-    {
-      "name": "nav_backwards",
-      "action_list": [
-        {
-          "trigger": "click",
-          "action_id": "set_active_item",
-          "args": [],
-          "_raw": "click | set_active_item | @item.index - 1",
-          "_cleaned": "click | set_active_item | @item.index - 1",
-          "params": {
-            "@item": {}
-          }
-        }
-      ],
-      "type": "set_variable",
-      "_nested_name": "nav_backwards",
-      "_dynamicFields": {
-        "action_list": {
-          "0": {
-            "_raw": [
-              {
-                "fullExpression": "click | set_active_item | @item.index - 1",
-                "matchedExpression": "@item.index",
-                "type": "item",
-                "fieldName": "index"
-              }
-            ],
-            "_cleaned": [
-              {
-                "fullExpression": "click | set_active_item | @item.index - 1",
-                "matchedExpression": "@item.index",
-                "type": "item",
-                "fieldName": "index"
-              }
-            ]
-          }
-        }
-      },
-      "_dynamicDependencies": {
-        "@item.index": [
-          "action_list.0._raw",
-          "action_list.0._cleaned"
         ]
       }
     }

--- a/app_data/sheets/template/debug/example_update_actions.json
+++ b/app_data/sheets/template/debug/example_update_actions.json
@@ -95,8 +95,8 @@
           "_cleaned": "click | pop_up:example_text"
         }
       ],
-      "name": "button",
-      "_nested_name": "button"
+      "name": "button_5",
+      "_nested_name": "button_5"
     },
     {
       "type": "set_field",

--- a/app_data/sheets/template/debug/example_widget_radio_button_box.json
+++ b/app_data/sheets/template/debug/example_widget_radio_button_box.json
@@ -7,9 +7,18 @@
     {
       "name": "answer_list",
       "value": [
-        "name:name_var_1 | text:happy",
-        "name:name_var_2 | text: ok",
-        "name:name_var_3 | text: sad"
+        {
+          "name": "name_var_1",
+          "text": "happy"
+        },
+        {
+          "name": "name_var_2",
+          "text": "ok"
+        },
+        {
+          "name": "name_var_3",
+          "text": "sad"
+        }
       ],
       "exclude_from_translation": true,
       "type": "set_variable",

--- a/app_data/sheets/template/debug/feature_combo_box.json
+++ b/app_data/sheets/template/debug/feature_combo_box.json
@@ -7,9 +7,18 @@
     {
       "name": "answer_list",
       "value": [
-        "name: name_1 | text: This is text 1",
-        "name: name_2 | text: This is text 2",
-        "name: name_3 | text: This is text 3"
+        {
+          "name": "name_1",
+          "text": "This is text 1"
+        },
+        {
+          "name": "name_2",
+          "text": "This is text 2"
+        },
+        {
+          "name": "name_3",
+          "text": "This is text 3"
+        }
       ],
       "exclude_from_translation": true,
       "type": "set_variable",

--- a/app_data/sheets/template/debug/feature_combo_box_placeholder.json
+++ b/app_data/sheets/template/debug/feature_combo_box_placeholder.json
@@ -7,9 +7,18 @@
     {
       "name": "answer_list",
       "value": [
-        "name: name_1 | text: This is text 1",
-        "name: name_2 | text: This is text 2",
-        "name: name_3 | text: This is text 3"
+        {
+          "name": "name_1",
+          "text": "This is text 1"
+        },
+        {
+          "name": "name_2",
+          "text": "This is text 2"
+        },
+        {
+          "name": "name_3",
+          "text": "This is text 3"
+        }
       ],
       "exclude_from_translation": true,
       "type": "set_variable",

--- a/app_data/sheets/template/debug/feature_dg_dashed_box.json
+++ b/app_data/sheets/template/debug/feature_dg_dashed_box.json
@@ -20,8 +20,8 @@
             "value": {}
           },
           "exclude_from_translation": true,
-          "name": "subtitle",
-          "_nested_name": "dg_example_dashed_box.subtitle"
+          "name": "subtitle_1",
+          "_nested_name": "dg_example_dashed_box.subtitle_1"
         },
         {
           "type": "parent_point_box",
@@ -63,8 +63,8 @@
             "value": {}
           },
           "exclude_from_translation": true,
-          "name": "image",
-          "_nested_name": "dg_example_dashed_box_2.image"
+          "name": "image_1",
+          "_nested_name": "dg_example_dashed_box_2.image_1"
         },
         {
           "type": "text",

--- a/app_data/sheets/template/debug/feature_dg_form.json
+++ b/app_data/sheets/template/debug/feature_dg_form.json
@@ -102,8 +102,8 @@
             "value": {}
           },
           "exclude_from_translation": true,
-          "name": "title",
-          "_nested_name": "dg_example_form.title"
+          "name": "title_5",
+          "_nested_name": "dg_example_form.title_5"
         },
         {
           "type": "text_area",

--- a/app_data/sheets/template/debug/feature_essential_tools.json
+++ b/app_data/sheets/template/debug/feature_essential_tools.json
@@ -28,7 +28,7 @@
           "style_list": [
             "margin-top:20px"
           ],
-          "_nested_name": "display_group.ft"
+          "_nested_name": "display_group_2.ft"
         },
         {
           "type": "text",
@@ -46,7 +46,7 @@
             "margin-top: 15px",
             "max-width: 320px"
           ],
-          "_nested_name": "display_group.ftt"
+          "_nested_name": "display_group_2.ftt"
         },
         {
           "type": "button",
@@ -59,11 +59,11 @@
           "parameter_list": {
             "style": "nested_color full-width"
           },
-          "_nested_name": "display_group.bt_1"
+          "_nested_name": "display_group_2.bt_1"
         }
       ],
-      "name": "display_group",
-      "_nested_name": "display_group"
+      "name": "display_group_2",
+      "_nested_name": "display_group_2"
     },
     {
       "type": "display_group",
@@ -89,7 +89,7 @@
           "style_list": [
             "margin-top:20px"
           ],
-          "_nested_name": "display_group.ft"
+          "_nested_name": "display_group_4.ft"
         },
         {
           "type": "subtitle",
@@ -105,7 +105,7 @@
           "style_list": [
             "margin-top: 15px"
           ],
-          "_nested_name": "display_group.ss"
+          "_nested_name": "display_group_4.ss"
         },
         {
           "type": "text",
@@ -123,7 +123,7 @@
             "margin-top: 15px",
             "max-width: 320px"
           ],
-          "_nested_name": "display_group.ftt"
+          "_nested_name": "display_group_4.ftt"
         },
         {
           "type": "button",
@@ -136,11 +136,11 @@
           "parameter_list": {
             "style": "nested_color full-width"
           },
-          "_nested_name": "display_group.bt_2"
+          "_nested_name": "display_group_4.bt_2"
         }
       ],
-      "name": "display_group",
-      "_nested_name": "display_group"
+      "name": "display_group_4",
+      "_nested_name": "display_group_4"
     },
     {
       "type": "display_group",
@@ -166,7 +166,7 @@
           "style_list": [
             "margin-top:20px"
           ],
-          "_nested_name": "display_group.ft"
+          "_nested_name": "display_group_6.ft"
         },
         {
           "type": "subtitle",
@@ -182,7 +182,7 @@
           "style_list": [
             "margin-top: 15px"
           ],
-          "_nested_name": "display_group.ss"
+          "_nested_name": "display_group_6.ss"
         },
         {
           "type": "text",
@@ -200,7 +200,7 @@
             "margin-top: 15px",
             "max-width: 320px"
           ],
-          "_nested_name": "display_group.ftt"
+          "_nested_name": "display_group_6.ftt"
         },
         {
           "type": "button",
@@ -213,17 +213,17 @@
           "parameter_list": {
             "style": "nested_color  full-width"
           },
-          "_nested_name": "display_group.bt_3"
+          "_nested_name": "display_group_6.bt_3"
         }
       ],
-      "name": "display_group",
-      "_nested_name": "display_group"
+      "name": "display_group_6",
+      "_nested_name": "display_group_6"
     },
     {
       "exclude_from_translation": true,
       "type": "set_variable",
-      "name": "set_variable",
-      "_nested_name": "set_variable"
+      "name": "set_variable_8",
+      "_nested_name": "set_variable_8"
     },
     {
       "type": "display_group",
@@ -249,7 +249,7 @@
           "style_list": [
             "margin-top:20px"
           ],
-          "_nested_name": "display_group.ft"
+          "_nested_name": "display_group_9.ft"
         },
         {
           "type": "subtitle",
@@ -265,7 +265,7 @@
           "style_list": [
             "margin-top: 15px"
           ],
-          "_nested_name": "display_group.ss"
+          "_nested_name": "display_group_9.ss"
         },
         {
           "type": "text",
@@ -283,7 +283,7 @@
             "margin-top: 15px",
             "max-width: 320px"
           ],
-          "_nested_name": "display_group.ftt"
+          "_nested_name": "display_group_9.ftt"
         },
         {
           "type": "button",
@@ -296,11 +296,11 @@
           "parameter_list": {
             "style": "nested_color full-width"
           },
-          "_nested_name": "display_group.bt_3"
+          "_nested_name": "display_group_9.bt_3"
         }
       ],
-      "name": "display_group",
-      "_nested_name": "display_group"
+      "name": "display_group_9",
+      "_nested_name": "display_group_9"
     },
     {
       "type": "display_group",
@@ -326,7 +326,7 @@
           "style_list": [
             "margin-top:20px"
           ],
-          "_nested_name": "display_group.ft"
+          "_nested_name": "display_group_11.ft"
         },
         {
           "type": "subtitle",
@@ -342,7 +342,7 @@
           "style_list": [
             "margin-top: 15px"
           ],
-          "_nested_name": "display_group.ss"
+          "_nested_name": "display_group_11.ss"
         },
         {
           "type": "text",
@@ -360,7 +360,7 @@
             "margin-top: 15px",
             "max-width: 320px"
           ],
-          "_nested_name": "display_group.ftt"
+          "_nested_name": "display_group_11.ftt"
         },
         {
           "type": "button",
@@ -373,17 +373,17 @@
           "parameter_list": {
             "style": "nested_color full-width"
           },
-          "_nested_name": "display_group.bt_3"
+          "_nested_name": "display_group_11.bt_3"
         }
       ],
-      "name": "display_group",
-      "_nested_name": "display_group"
+      "name": "display_group_11",
+      "_nested_name": "display_group_11"
     },
     {
       "exclude_from_translation": true,
       "type": "set_variable",
-      "name": "set_variable",
-      "_nested_name": "set_variable"
+      "name": "set_variable_13",
+      "_nested_name": "set_variable_13"
     },
     {
       "type": "display_group",
@@ -409,7 +409,7 @@
           "style_list": [
             "margin-top:20px"
           ],
-          "_nested_name": "display_group.ft"
+          "_nested_name": "display_group_14.ft"
         },
         {
           "type": "subtitle",
@@ -425,7 +425,7 @@
           "style_list": [
             "margin-top: 15px"
           ],
-          "_nested_name": "display_group.ss"
+          "_nested_name": "display_group_14.ss"
         },
         {
           "type": "text",
@@ -443,7 +443,7 @@
             "margin-top: 15px",
             "max-width: 320px"
           ],
-          "_nested_name": "display_group.ftt"
+          "_nested_name": "display_group_14.ftt"
         },
         {
           "type": "image",
@@ -456,11 +456,11 @@
           "parameter_list": {
             "style": "corner"
           },
-          "_nested_name": "display_group.image"
+          "_nested_name": "display_group_14.image"
         }
       ],
-      "name": "display_group",
-      "_nested_name": "display_group"
+      "name": "display_group_14",
+      "_nested_name": "display_group_14"
     },
     {
       "type": "display_group",
@@ -483,7 +483,7 @@
           "parameter_list": {
             "style": "white"
           },
-          "_nested_name": "display_group.ft"
+          "_nested_name": "display_group_16.ft"
         },
         {
           "type": "text",
@@ -501,7 +501,7 @@
             "margin-top: 10px",
             "max-width: 320px"
           ],
-          "_nested_name": "display_group.ftt"
+          "_nested_name": "display_group_16.ftt"
         },
         {
           "type": "display_group",
@@ -522,14 +522,14 @@
                 "value": {}
               },
               "exclude_from_translation": true,
-              "_nested_name": "display_group.bgg_1.image"
+              "_nested_name": "display_group_16.bgg_1.image"
             }
           ],
-          "_nested_name": "display_group.bgg_1"
+          "_nested_name": "display_group_16.bgg_1"
         }
       ],
-      "name": "display_group",
-      "_nested_name": "display_group"
+      "name": "display_group_16",
+      "_nested_name": "display_group_16"
     },
     {
       "type": "display_group",
@@ -552,7 +552,7 @@
           "parameter_list": {
             "style": "white"
           },
-          "_nested_name": "display_group.ft"
+          "_nested_name": "display_group_18.ft"
         },
         {
           "type": "text",
@@ -570,7 +570,7 @@
             "margin-top: 10px",
             "max-width: 320px"
           ],
-          "_nested_name": "display_group.ftt"
+          "_nested_name": "display_group_18.ftt"
         },
         {
           "type": "display_group",
@@ -591,14 +591,14 @@
                 "value": {}
               },
               "exclude_from_translation": true,
-              "_nested_name": "display_group.bgg_1.image"
+              "_nested_name": "display_group_18.bgg_1.image"
             }
           ],
-          "_nested_name": "display_group.bgg_1"
+          "_nested_name": "display_group_18.bgg_1"
         }
       ],
-      "name": "display_group",
-      "_nested_name": "display_group"
+      "name": "display_group_18",
+      "_nested_name": "display_group_18"
     }
   ],
   "_xlsxPath": "feature_sheets/to_be_sorted/feature_template_components.xlsx"

--- a/app_data/sheets/template/debug/feature_home.json
+++ b/app_data/sheets/template/debug/feature_home.json
@@ -63,7 +63,7 @@
                 "margin-bottom: 8px",
                 "margin-top: 15px"
               ],
-              "_nested_name": "dg_example_7.display_group.title_ex_s",
+              "_nested_name": "dg_example_7.display_group_2.title_ex_s",
               "_dynamicFields": {
                 "value": [
                   {
@@ -96,11 +96,11 @@
               "style_list": [
                 "padding: 0"
               ],
-              "_nested_name": "dg_example_7.display_group.round_button_1"
+              "_nested_name": "dg_example_7.display_group_2.round_button_1"
             }
           ],
-          "name": "display_group",
-          "_nested_name": "dg_example_7.display_group"
+          "name": "display_group_2",
+          "_nested_name": "dg_example_7.display_group_2"
         }
       ],
       "_nested_name": "dg_example_7"
@@ -140,8 +140,8 @@
         {
           "exclude_from_translation": true,
           "type": "set_variable",
-          "name": "set_variable",
-          "_nested_name": "dg_example_7.set_variable"
+          "name": "set_variable_2",
+          "_nested_name": "dg_example_7.set_variable_2"
         },
         {
           "type": "display_group",
@@ -169,7 +169,7 @@
                 "white-space: nowrap",
                 "margin-top: 15px"
               ],
-              "_nested_name": "dg_example_7.display_group.title_ex_s",
+              "_nested_name": "dg_example_7.display_group_3.title_ex_s",
               "_dynamicFields": {
                 "value": [
                   {
@@ -202,11 +202,11 @@
               "style_list": [
                 "padding: 0"
               ],
-              "_nested_name": "dg_example_7.display_group.round_button_1"
+              "_nested_name": "dg_example_7.display_group_3.round_button_1"
             }
           ],
-          "name": "display_group",
-          "_nested_name": "dg_example_7.display_group"
+          "name": "display_group_3",
+          "_nested_name": "dg_example_7.display_group_3"
         }
       ],
       "_nested_name": "dg_example_7"
@@ -269,7 +269,7 @@
                 "white-space: nowrap",
                 "margin-top:15px"
               ],
-              "_nested_name": "dg_example_7.display_group.title_ex_s",
+              "_nested_name": "dg_example_7.display_group_2.title_ex_s",
               "_dynamicFields": {
                 "value": [
                   {
@@ -301,17 +301,17 @@
               "style_list": [
                 "padding: 0"
               ],
-              "_nested_name": "dg_example_7.display_group.round_button_1"
+              "_nested_name": "dg_example_7.display_group_2.round_button_1"
             }
           ],
-          "name": "display_group",
-          "_nested_name": "dg_example_7.display_group"
+          "name": "display_group_2",
+          "_nested_name": "dg_example_7.display_group_2"
         },
         {
           "exclude_from_translation": true,
           "type": "set_variable",
-          "name": "set_variable",
-          "_nested_name": "dg_example_7.set_variable"
+          "name": "set_variable_3",
+          "_nested_name": "dg_example_7.set_variable_3"
         }
       ],
       "_nested_name": "dg_example_7"

--- a/app_data/sheets/template/debug/feature_parent_point_box.json
+++ b/app_data/sheets/template/debug/feature_parent_point_box.json
@@ -152,9 +152,10 @@
         },
         {
           "name": "icon_button_action_list",
-          "value": [
-            "click | set_field : something : dsfsd"
-          ],
+          "value": "click | set_field : something : dsfsd",
+          "_translations": {
+            "value": {}
+          },
           "type": "set_variable",
           "_nested_name": "dg.icon_button_action_list"
         },
@@ -540,8 +541,8 @@
         "value": {}
       },
       "exclude_from_translation": true,
-      "name": "title",
-      "_nested_name": "title"
+      "name": "title_7",
+      "_nested_name": "title_7"
     },
     {
       "type": "display_group",

--- a/app_data/sheets/template/debug/feature_radio_group.json
+++ b/app_data/sheets/template/debug/feature_radio_group.json
@@ -7,8 +7,14 @@
     {
       "name": "answer0_list",
       "value": [
-        "name:name_var_1 | text:Single",
-        "name:name_var_2 | text:Pair"
+        {
+          "name": "name_var_1",
+          "text": "Single"
+        },
+        {
+          "name": "name_var_2",
+          "text": "Pair"
+        }
       ],
       "exclude_from_translation": true,
       "type": "set_variable",
@@ -127,9 +133,21 @@
     {
       "name": "answer2_list",
       "value": [
-        "name:name_var_1 | text:Black| image:/plh_images/icons/heart.svg",
-        "name:name_var_2| image:/plh_images/icons/heart.svg | text:White",
-        "name:name_var_3| image:/plh_images/icons/heart.svg | text:Blue"
+        {
+          "name": "name_var_1",
+          "text": "Black",
+          "image": "/plh_images/icons/heart.svg"
+        },
+        {
+          "name": "name_var_2",
+          "image": "/plh_images/icons/heart.svg",
+          "text": "White"
+        },
+        {
+          "name": "name_var_3",
+          "image": "/plh_images/icons/heart.svg",
+          "text": "Blue"
+        }
       ],
       "exclude_from_translation": true,
       "type": "set_variable",
@@ -138,9 +156,18 @@
     {
       "name": "answer3_list",
       "value": [
-        "name:name_var_1 | image:/plh_images/icons/heart.svg",
-        "name:name_var_2| image:/plh_images/icons/heart.svg",
-        "name:name_var_3| image:/plh_images/icons/heart.svg"
+        {
+          "name": "name_var_1",
+          "image": "/plh_images/icons/heart.svg"
+        },
+        {
+          "name": "name_var_2",
+          "image": "/plh_images/icons/heart.svg"
+        },
+        {
+          "name": "name_var_3",
+          "image": "/plh_images/icons/heart.svg"
+        }
       ],
       "exclude_from_translation": true,
       "type": "set_variable",

--- a/app_data/sheets/template/debug/feature_radio_group_2.json
+++ b/app_data/sheets/template/debug/feature_radio_group_2.json
@@ -7,10 +7,30 @@
     {
       "name": "answer_list_1",
       "value": [
-        "name:name_var_1 | text:First | image:/plh_images/icons/heart.svg | image_checked: /plh_images/icons/tick.svg",
-        "name:name_var_2 | text:Second | image:/plh_images/icons/heart.svg | image_checked: /plh_images/icons/tick.svg",
-        "name:name_var_3 | text: Third | image:/plh_images/icons/heart.svg | image_checked: /plh_images/icons/tick.svg",
-        "name:name_var_4 | text:Fourth | image:/plh_images/icons/heart.svg | image_checked: /plh_images/icons/tick.svg"
+        {
+          "name": "name_var_1",
+          "text": "First",
+          "image": "/plh_images/icons/heart.svg",
+          "image_checked": "/plh_images/icons/tick.svg"
+        },
+        {
+          "name": "name_var_2",
+          "text": "Second",
+          "image": "/plh_images/icons/heart.svg",
+          "image_checked": "/plh_images/icons/tick.svg"
+        },
+        {
+          "name": "name_var_3",
+          "text": "Third",
+          "image": "/plh_images/icons/heart.svg",
+          "image_checked": "/plh_images/icons/tick.svg"
+        },
+        {
+          "name": "name_var_4",
+          "text": "Fourth",
+          "image": "/plh_images/icons/heart.svg",
+          "image_checked": "/plh_images/icons/tick.svg"
+        }
       ],
       "exclude_from_translation": true,
       "type": "set_variable",
@@ -19,8 +39,16 @@
     {
       "name": "answer_list_2",
       "value": [
-        "name:name_var_1 | text:First | image:/plh_images/icons/heart.svg",
-        "name:name_var_2 | text:Second | image:/plh_images/icons/heart.svg"
+        {
+          "name": "name_var_1",
+          "text": "First",
+          "image": "/plh_images/icons/heart.svg"
+        },
+        {
+          "name": "name_var_2",
+          "text": "Second",
+          "image": "/plh_images/icons/heart.svg"
+        }
       ],
       "exclude_from_translation": true,
       "type": "set_variable",
@@ -29,8 +57,18 @@
     {
       "name": "answer_list_3",
       "value": [
-        "name:name_var_1 | text:First | image:/plh_images/icons/heart.svg | image_checked: /plh_images/icons/tick.svg",
-        "name:name_var_2 | text:Second | image:/plh_images/icons/heart.svg | image_checked: /plh_images/icons/tick.svg"
+        {
+          "name": "name_var_1",
+          "text": "First",
+          "image": "/plh_images/icons/heart.svg",
+          "image_checked": "/plh_images/icons/tick.svg"
+        },
+        {
+          "name": "name_var_2",
+          "text": "Second",
+          "image": "/plh_images/icons/heart.svg",
+          "image_checked": "/plh_images/icons/tick.svg"
+        }
       ],
       "exclude_from_translation": true,
       "type": "set_variable",
@@ -39,9 +77,18 @@
     {
       "name": "answer_list_4",
       "value": [
-        "name:name_var_1 | text:First",
-        "name:name_var_2 | text:Second",
-        "name:name_var_3 | text:Third"
+        {
+          "name": "name_var_1",
+          "text": "First"
+        },
+        {
+          "name": "name_var_2",
+          "text": "Second"
+        },
+        {
+          "name": "name_var_3",
+          "text": "Third"
+        }
       ],
       "exclude_from_translation": true,
       "type": "set_variable",
@@ -50,9 +97,21 @@
     {
       "name": "answer_list_5",
       "value": [
-        "name:happy | image:plh_images/stickers/faces/happy.svg | image_checked:plh_images/stickers/faces/happy.svg",
-        "name:happier | image:plh_images/stickers/faces/happier.svg | image_checked:plh_images/stickers/faces/happier.svg",
-        "name:happiest | image:plh_images/stickers/faces/happiest.svg | image_checked:plh_images/stickers/faces/happiest.svg"
+        {
+          "name": "happy",
+          "image": "plh_images/stickers/faces/happy.svg",
+          "image_checked": "plh_images/stickers/faces/happy.svg"
+        },
+        {
+          "name": "happier",
+          "image": "plh_images/stickers/faces/happier.svg",
+          "image_checked": "plh_images/stickers/faces/happier.svg"
+        },
+        {
+          "name": "happiest",
+          "image": "plh_images/stickers/faces/happiest.svg",
+          "image_checked": "plh_images/stickers/faces/happiest.svg"
+        }
       ],
       "exclude_from_translation": true,
       "type": "set_variable",
@@ -61,9 +120,21 @@
     {
       "name": "answer_list_6",
       "value": [
-        "name:happy | image:plh_images/stickers/faces_yellow/happy.svg | image_checked:plh_images/stickers/faces_yellow/happy.svg",
-        "name:happier | image:plh_images/stickers/faces_yellow/happier.svg | image_checked:plh_images/stickers/faces_yellow/happier.svg",
-        "name:happiest | image:plh_images/stickers/faces_yellow/happiest.svg | image_checked:plh_images/stickers/faces_yellow/happiest.svg"
+        {
+          "name": "happy",
+          "image": "plh_images/stickers/faces_yellow/happy.svg",
+          "image_checked": "plh_images/stickers/faces_yellow/happy.svg"
+        },
+        {
+          "name": "happier",
+          "image": "plh_images/stickers/faces_yellow/happier.svg",
+          "image_checked": "plh_images/stickers/faces_yellow/happier.svg"
+        },
+        {
+          "name": "happiest",
+          "image": "plh_images/stickers/faces_yellow/happiest.svg",
+          "image_checked": "plh_images/stickers/faces_yellow/happiest.svg"
+        }
       ],
       "exclude_from_translation": true,
       "type": "set_variable",
@@ -72,8 +143,16 @@
     {
       "name": "answer_list_7",
       "value": [
-        "name:happy | image:plh_images/stickers/faces_yellow/happy.svg | image_checked:plh_images/stickers/faces_yellow/happy.svg",
-        "name:happier | image:plh_images/stickers/faces_yellow/happier.svg | image_checked:plh_images/stickers/faces_yellow/happier.svg"
+        {
+          "name": "happy",
+          "image": "plh_images/stickers/faces_yellow/happy.svg",
+          "image_checked": "plh_images/stickers/faces_yellow/happy.svg"
+        },
+        {
+          "name": "happier",
+          "image": "plh_images/stickers/faces_yellow/happier.svg",
+          "image_checked": "plh_images/stickers/faces_yellow/happier.svg"
+        }
       ],
       "exclude_from_translation": true,
       "type": "set_variable",
@@ -445,8 +524,8 @@
         "value": {}
       },
       "exclude_from_translation": true,
-      "name": "text",
-      "_nested_name": "text"
+      "name": "text_23",
+      "_nested_name": "text_23"
     },
     {
       "type": "radio_group",
@@ -481,8 +560,8 @@
         "value": {}
       },
       "exclude_from_translation": true,
-      "name": "text",
-      "_nested_name": "text"
+      "name": "text_25",
+      "_nested_name": "text_25"
     },
     {
       "type": "radio_group",
@@ -518,8 +597,8 @@
         "value": {}
       },
       "exclude_from_translation": true,
-      "name": "text",
-      "_nested_name": "text"
+      "name": "text_27",
+      "_nested_name": "text_27"
     },
     {
       "type": "radio_group",
@@ -555,8 +634,8 @@
         "value": {}
       },
       "exclude_from_translation": true,
-      "name": "text",
-      "_nested_name": "text"
+      "name": "text_29",
+      "_nested_name": "text_29"
     },
     {
       "type": "radio_group",

--- a/app_data/sheets/template/debug/feature_tile.json
+++ b/app_data/sheets/template/debug/feature_tile.json
@@ -324,8 +324,8 @@
         "style": "image_text",
         "icon_src": "plh_images/workshops/w_self_care/tools.svg"
       },
-      "name": "tile_component",
-      "_nested_name": "tile_component"
+      "name": "tile_component_31",
+      "_nested_name": "tile_component_31"
     },
     {
       "type": "display_group",
@@ -341,8 +341,8 @@
             "style": "image_text",
             "icon_src": "plh_images/workshops/w_self_care/tools.svg"
           },
-          "name": "tile_component",
-          "_nested_name": "display_group.tile_component"
+          "name": "tile_component_1",
+          "_nested_name": "display_group_32.tile_component_1"
         },
         {
           "type": "tile_component",
@@ -352,8 +352,8 @@
             "style": "image_text",
             "icon_src": "plh_images/workshops/w_1on1/tools.svg"
           },
-          "name": "tile_component",
-          "_nested_name": "display_group.tile_component"
+          "name": "tile_component_2",
+          "_nested_name": "display_group_32.tile_component_2"
         },
         {
           "type": "tile_component",
@@ -363,8 +363,8 @@
             "style": "image_text",
             "icon_src": "plh_images/workshops/w_praise/tools.svg"
           },
-          "name": "tile_component",
-          "_nested_name": "display_group.tile_component"
+          "name": "tile_component_3",
+          "_nested_name": "display_group_32.tile_component_3"
         },
         {
           "type": "tile_component",
@@ -374,8 +374,8 @@
             "style": "image_text",
             "icon_src": "plh_images/workshops/w_instruct/tools.svg"
           },
-          "name": "tile_component",
-          "_nested_name": "display_group.tile_component"
+          "name": "tile_component_4",
+          "_nested_name": "display_group_32.tile_component_4"
         },
         {
           "type": "tile_component",
@@ -385,8 +385,8 @@
             "style": "image_text",
             "icon_src": "plh_images/workshops/w_stress/tools.svg"
           },
-          "name": "tile_component",
-          "_nested_name": "display_group.tile_component"
+          "name": "tile_component_5",
+          "_nested_name": "display_group_32.tile_component_5"
         },
         {
           "type": "tile_component",
@@ -396,8 +396,8 @@
             "style": "image_text",
             "icon_src": "plh_images/workshops/w_money/tools.svg"
           },
-          "name": "tile_component",
-          "_nested_name": "display_group.tile_component"
+          "name": "tile_component_6",
+          "_nested_name": "display_group_32.tile_component_6"
         },
         {
           "type": "tile_component",
@@ -407,8 +407,8 @@
             "style": "image_text",
             "icon_src": "plh_images/workshops/w_rules/tools.svg"
           },
-          "name": "tile_component",
-          "_nested_name": "display_group.tile_component"
+          "name": "tile_component_7",
+          "_nested_name": "display_group_32.tile_component_7"
         },
         {
           "type": "tile_component",
@@ -418,8 +418,8 @@
             "style": "image_text",
             "icon_src": "plh_images/workshops/w_consequence/tools.svg"
           },
-          "name": "tile_component",
-          "_nested_name": "display_group.tile_component"
+          "name": "tile_component_8",
+          "_nested_name": "display_group_32.tile_component_8"
         },
         {
           "type": "tile_component",
@@ -429,8 +429,8 @@
             "style": "image_text",
             "icon_src": "plh_images/workshops/w_safe/tools.svg"
           },
-          "name": "tile_component",
-          "_nested_name": "display_group.tile_component"
+          "name": "tile_component_9",
+          "_nested_name": "display_group_32.tile_component_9"
         },
         {
           "type": "tile_component",
@@ -440,8 +440,8 @@
             "style": "image_text",
             "icon_src": "plh_images/workshops/w_crisis/tools.svg"
           },
-          "name": "tile_component",
-          "_nested_name": "display_group.tile_component"
+          "name": "tile_component_10",
+          "_nested_name": "display_group_32.tile_component_10"
         },
         {
           "type": "tile_component",
@@ -451,12 +451,12 @@
             "style": "image_text",
             "icon_src": "plh_images/workshops/w_celebrate/tools.svg"
           },
-          "name": "tile_component",
-          "_nested_name": "display_group.tile_component"
+          "name": "tile_component_11",
+          "_nested_name": "display_group_32.tile_component_11"
         }
       ],
-      "name": "display_group",
-      "_nested_name": "display_group"
+      "name": "display_group_32",
+      "_nested_name": "display_group_32"
     }
   ],
   "_xlsxPath": "feature_sheets/to_be_sorted/feature_template_components.xlsx"

--- a/app_data/sheets/template/debug/feature_two_columns_images.json
+++ b/app_data/sheets/template/debug/feature_two_columns_images.json
@@ -14,8 +14,8 @@
         "style": "center",
         "text_align": "center"
       },
-      "name": "title",
-      "_nested_name": "title"
+      "name": "title_2",
+      "_nested_name": "title_2"
     },
     {
       "type": "display_group",
@@ -31,7 +31,7 @@
             "value": {}
           },
           "exclude_from_translation": true,
-          "_nested_name": "display_group.partner_1"
+          "_nested_name": "display_group_3.partner_1"
         },
         {
           "type": "image",
@@ -41,7 +41,7 @@
             "value": {}
           },
           "exclude_from_translation": true,
-          "_nested_name": "display_group.partner_2"
+          "_nested_name": "display_group_3.partner_2"
         },
         {
           "type": "image",
@@ -51,7 +51,7 @@
             "value": {}
           },
           "exclude_from_translation": true,
-          "_nested_name": "display_group.partner_3"
+          "_nested_name": "display_group_3.partner_3"
         },
         {
           "type": "image",
@@ -61,7 +61,7 @@
             "value": {}
           },
           "exclude_from_translation": true,
-          "_nested_name": "display_group.partner_4"
+          "_nested_name": "display_group_3.partner_4"
         },
         {
           "type": "image",
@@ -71,11 +71,11 @@
             "value": {}
           },
           "exclude_from_translation": true,
-          "_nested_name": "display_group.partner_5"
+          "_nested_name": "display_group_3.partner_5"
         }
       ],
-      "name": "display_group",
-      "_nested_name": "display_group"
+      "name": "display_group_3",
+      "_nested_name": "display_group_3"
     }
   ],
   "_xlsxPath": "feature_sheets/to_be_sorted/feature_template_components.xlsx"

--- a/app_data/sheets/template/debug/feature_two_columns_images_2.json
+++ b/app_data/sheets/template/debug/feature_two_columns_images_2.json
@@ -14,8 +14,8 @@
         "style": "center",
         "text_align": "center"
       },
-      "name": "title",
-      "_nested_name": "title"
+      "name": "title_2",
+      "_nested_name": "title_2"
     },
     {
       "type": "display_group",
@@ -31,7 +31,7 @@
             "value": {}
           },
           "exclude_from_translation": true,
-          "_nested_name": "display_group.funder_1"
+          "_nested_name": "display_group_3.funder_1"
         },
         {
           "type": "image",
@@ -41,7 +41,7 @@
             "value": {}
           },
           "exclude_from_translation": true,
-          "_nested_name": "display_group.funder_2"
+          "_nested_name": "display_group_3.funder_2"
         },
         {
           "type": "image",
@@ -51,7 +51,7 @@
             "value": {}
           },
           "exclude_from_translation": true,
-          "_nested_name": "display_group.funder_3"
+          "_nested_name": "display_group_3.funder_3"
         },
         {
           "type": "image",
@@ -61,7 +61,7 @@
             "value": {}
           },
           "exclude_from_translation": true,
-          "_nested_name": "display_group.funder_4"
+          "_nested_name": "display_group_3.funder_4"
         },
         {
           "type": "image",
@@ -71,7 +71,7 @@
             "value": {}
           },
           "exclude_from_translation": true,
-          "_nested_name": "display_group.funder_5"
+          "_nested_name": "display_group_3.funder_5"
         },
         {
           "type": "image",
@@ -81,7 +81,7 @@
             "value": {}
           },
           "exclude_from_translation": true,
-          "_nested_name": "display_group.funder_6"
+          "_nested_name": "display_group_3.funder_6"
         },
         {
           "type": "image",
@@ -91,7 +91,7 @@
             "value": {}
           },
           "exclude_from_translation": true,
-          "_nested_name": "display_group.funder_7"
+          "_nested_name": "display_group_3.funder_7"
         },
         {
           "type": "image",
@@ -101,7 +101,7 @@
             "value": {}
           },
           "exclude_from_translation": true,
-          "_nested_name": "display_group.funder_8"
+          "_nested_name": "display_group_3.funder_8"
         },
         {
           "type": "image",
@@ -111,7 +111,7 @@
             "value": {}
           },
           "exclude_from_translation": true,
-          "_nested_name": "display_group.funder_9"
+          "_nested_name": "display_group_3.funder_9"
         },
         {
           "type": "image",
@@ -121,11 +121,11 @@
             "value": {}
           },
           "exclude_from_translation": true,
-          "_nested_name": "display_group.funder_10"
+          "_nested_name": "display_group_3.funder_10"
         }
       ],
-      "name": "display_group",
-      "_nested_name": "display_group"
+      "name": "display_group_3",
+      "_nested_name": "display_group_3"
     }
   ],
   "_xlsxPath": "feature_sheets/to_be_sorted/feature_template_components.xlsx"

--- a/app_data/sheets/template/debug/navigation_bar.json
+++ b/app_data/sheets/template/debug/navigation_bar.json
@@ -7,49 +7,70 @@
     {
       "name": "button_list",
       "value": [
-        "name: home_screen_button | text: @global.home_screen | image: plh_images/icons/house_white.svg | target_template: home_screen",
-        "name: parent_points_button | text: @global.parent_points | image: plh_images/icons/parent_child_white.svg | target_template: parent_points",
-        "name: parent_library_button | text: @global.parent_centre | image: plh_images/icons/book_white.svg | target_template: parent_centre"
+        {
+          "name": "home_screen_button",
+          "text": "@global.home_screen",
+          "image": "plh_images/icons/house_white.svg",
+          "target_template": "home_screen"
+        },
+        {
+          "name": "parent_points_button",
+          "text": "@global.parent_points",
+          "image": "plh_images/icons/parent_child_white.svg",
+          "target_template": "parent_points"
+        },
+        {
+          "name": "parent_library_button",
+          "text": "@global.parent_centre",
+          "image": "plh_images/icons/book_white.svg",
+          "target_template": "parent_centre"
+        }
       ],
       "type": "set_variable",
       "_nested_name": "button_list",
       "_dynamicFields": {
         "value": {
-          "0": [
-            {
-              "fullExpression": "name: home_screen_button | text: @global.home_screen | image: plh_images/icons/house_white.svg | target_template: home_screen",
-              "matchedExpression": "@global.home_screen",
-              "type": "global",
-              "fieldName": "home_screen"
-            }
-          ],
-          "1": [
-            {
-              "fullExpression": "name: parent_points_button | text: @global.parent_points | image: plh_images/icons/parent_child_white.svg | target_template: parent_points",
-              "matchedExpression": "@global.parent_points",
-              "type": "global",
-              "fieldName": "parent_points"
-            }
-          ],
-          "2": [
-            {
-              "fullExpression": "name: parent_library_button | text: @global.parent_centre | image: plh_images/icons/book_white.svg | target_template: parent_centre",
-              "matchedExpression": "@global.parent_centre",
-              "type": "global",
-              "fieldName": "parent_centre"
-            }
-          ]
+          "0": {
+            "text": [
+              {
+                "fullExpression": "@global.home_screen",
+                "matchedExpression": "@global.home_screen",
+                "type": "global",
+                "fieldName": "home_screen"
+              }
+            ]
+          },
+          "1": {
+            "text": [
+              {
+                "fullExpression": "@global.parent_points",
+                "matchedExpression": "@global.parent_points",
+                "type": "global",
+                "fieldName": "parent_points"
+              }
+            ]
+          },
+          "2": {
+            "text": [
+              {
+                "fullExpression": "@global.parent_centre",
+                "matchedExpression": "@global.parent_centre",
+                "type": "global",
+                "fieldName": "parent_centre"
+              }
+            ]
+          }
         }
       },
       "_dynamicDependencies": {
         "@global.home_screen": [
-          "value.0"
+          "value.0.text"
         ],
         "@global.parent_points": [
-          "value.1"
+          "value.1.text"
         ],
         "@global.parent_centre": [
-          "value.2"
+          "value.2.text"
         ]
       }
     },
@@ -58,8 +79,8 @@
       "parameter_list": {
         "button_list": "@local.button_list"
       },
-      "name": "navigation_bar",
-      "_nested_name": "navigation_bar",
+      "name": "navigation_bar_3",
+      "_nested_name": "navigation_bar_3",
       "_dynamicFields": {
         "parameter_list": {
           "button_list": [

--- a/app_data/sheets/template/debug/navigation_bar_display_group.json
+++ b/app_data/sheets/template/debug/navigation_bar_display_group.json
@@ -22,8 +22,8 @@
               "_translations": {
                 "value": {}
               },
-              "name": "image",
-              "_nested_name": "display_group.display_group.image"
+              "name": "image_1",
+              "_nested_name": "display_group_2.display_group_1.image_1"
             },
             {
               "type": "text",
@@ -35,8 +35,8 @@
                 "text_align": "center",
                 "style": "alternative"
               },
-              "name": "text",
-              "_nested_name": "display_group.display_group.text",
+              "name": "text_2",
+              "_nested_name": "display_group_2.display_group_1.text_2",
               "_dynamicFields": {
                 "value": [
                   {
@@ -54,8 +54,8 @@
               }
             }
           ],
-          "name": "display_group",
-          "_nested_name": "display_group.display_group"
+          "name": "display_group_1",
+          "_nested_name": "display_group_2.display_group_1"
         },
         {
           "type": "display_group",
@@ -69,8 +69,8 @@
               "_translations": {
                 "value": {}
               },
-              "name": "image",
-              "_nested_name": "display_group.display_group.image"
+              "name": "image_1",
+              "_nested_name": "display_group_2.display_group_2.image_1"
             },
             {
               "type": "text",
@@ -82,8 +82,8 @@
                 "text_align": "center",
                 "style": "alternative"
               },
-              "name": "text",
-              "_nested_name": "display_group.display_group.text",
+              "name": "text_2",
+              "_nested_name": "display_group_2.display_group_2.text_2",
               "_dynamicFields": {
                 "value": [
                   {
@@ -101,8 +101,8 @@
               }
             }
           ],
-          "name": "display_group",
-          "_nested_name": "display_group.display_group"
+          "name": "display_group_2",
+          "_nested_name": "display_group_2.display_group_2"
         },
         {
           "type": "display_group",
@@ -116,8 +116,8 @@
               "_translations": {
                 "value": {}
               },
-              "name": "image",
-              "_nested_name": "display_group.display_group.image"
+              "name": "image_1",
+              "_nested_name": "display_group_2.display_group_3.image_1"
             },
             {
               "type": "text",
@@ -129,8 +129,8 @@
                 "text_align": "center",
                 "style": "alternative"
               },
-              "name": "text",
-              "_nested_name": "display_group.display_group.text",
+              "name": "text_2",
+              "_nested_name": "display_group_2.display_group_3.text_2",
               "_dynamicFields": {
                 "value": [
                   {
@@ -148,12 +148,12 @@
               }
             }
           ],
-          "name": "display_group",
-          "_nested_name": "display_group.display_group"
+          "name": "display_group_3",
+          "_nested_name": "display_group_2.display_group_3"
         }
       ],
-      "name": "display_group",
-      "_nested_name": "display_group"
+      "name": "display_group_2",
+      "_nested_name": "display_group_2"
     }
   ],
   "_xlsxPath": "example_sheets/example_footer.xlsx"

--- a/app_data/sheets/template/debug/tg_1_subtask_1.json
+++ b/app_data/sheets/template/debug/tg_1_subtask_1.json
@@ -10,8 +10,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "title",
-      "_nested_name": "title"
+      "name": "title_2",
+      "_nested_name": "title_2"
     },
     {
       "type": "text",
@@ -19,8 +19,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "text",
-      "_nested_name": "text"
+      "name": "text_3",
+      "_nested_name": "text_3"
     }
   ],
   "_xlsxPath": "example_sheets/example_task_group_stepper.xlsx"

--- a/app_data/sheets/template/debug/tg_1_subtask_2.json
+++ b/app_data/sheets/template/debug/tg_1_subtask_2.json
@@ -10,8 +10,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "title",
-      "_nested_name": "title"
+      "name": "title_2",
+      "_nested_name": "title_2"
     },
     {
       "type": "image",
@@ -19,8 +19,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "image",
-      "_nested_name": "image"
+      "name": "image_3",
+      "_nested_name": "image_3"
     }
   ],
   "_xlsxPath": "example_sheets/example_task_group_stepper.xlsx"

--- a/app_data/sheets/template/debug/tg_1_subtask_3.json
+++ b/app_data/sheets/template/debug/tg_1_subtask_3.json
@@ -10,8 +10,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "title",
-      "_nested_name": "title"
+      "name": "title_2",
+      "_nested_name": "title_2"
     },
     {
       "type": "text",
@@ -19,8 +19,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "text",
-      "_nested_name": "text"
+      "name": "text_3",
+      "_nested_name": "text_3"
     }
   ],
   "_xlsxPath": "example_sheets/example_task_group_stepper.xlsx"

--- a/app_data/sheets/template/debug/user_actions.json
+++ b/app_data/sheets/template/debug/user_actions.json
@@ -10,8 +10,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "title",
-      "_nested_name": "title"
+      "name": "title_2",
+      "_nested_name": "title_2"
     },
     {
       "type": "title",
@@ -19,8 +19,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "title",
-      "_nested_name": "title"
+      "name": "title_3",
+      "_nested_name": "title_3"
     },
     {
       "type": "text",
@@ -28,8 +28,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "text",
-      "_nested_name": "text"
+      "name": "text_4",
+      "_nested_name": "text_4"
     },
     {
       "type": "text_box",
@@ -58,8 +58,8 @@
           "_cleaned": "changed | emit : force_reprocess"
         }
       ],
-      "name": "text_box",
-      "_nested_name": "text_box",
+      "name": "text_box_5",
+      "_nested_name": "text_box_5",
       "_dynamicFields": {
         "value": [
           {
@@ -82,8 +82,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "text",
-      "_nested_name": "text",
+      "name": "text_6",
+      "_nested_name": "text_6",
       "_dynamicFields": {
         "value": [
           {
@@ -106,8 +106,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "text",
-      "_nested_name": "text",
+      "name": "text_7",
+      "_nested_name": "text_7",
       "_dynamicFields": {
         "value": [
           {
@@ -130,8 +130,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "text",
-      "_nested_name": "text",
+      "name": "text_8",
+      "_nested_name": "text_8",
       "_dynamicFields": {
         "value": [
           {
@@ -174,8 +174,8 @@
           "_cleaned": "click | emit : force_reprocess"
         }
       ],
-      "name": "button",
-      "_nested_name": "button"
+      "name": "button_9",
+      "_nested_name": "button_9"
     },
     {
       "type": "title",
@@ -183,8 +183,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "title",
-      "_nested_name": "title"
+      "name": "title_10",
+      "_nested_name": "title_10"
     },
     {
       "type": "text",
@@ -192,8 +192,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "text",
-      "_nested_name": "text"
+      "name": "text_11",
+      "_nested_name": "text_11"
     },
     {
       "type": "text_box",
@@ -227,8 +227,8 @@
           "_cleaned": "click | emit : force_reprocess"
         }
       ],
-      "name": "button",
-      "_nested_name": "button",
+      "name": "button_13",
+      "_nested_name": "button_13",
       "_dynamicFields": {
         "action_list": {
           "0": {

--- a/app_data/sheets/template/debug/w_example_stepper.json
+++ b/app_data/sheets/template/debug/w_example_stepper.json
@@ -115,9 +115,10 @@
       "rows": [
         {
           "name": "nav_template_list",
-          "value": [
-            "w_example_listen"
-          ],
+          "value": "w_example_listen",
+          "_translations": {
+            "value": {}
+          },
           "exclude_from_translation": true,
           "type": "set_variable",
           "_nested_name": "workshop_stepper_individual.nav_template_list"

--- a/app_data/sheets/template/debug_answer_list_partial.json
+++ b/app_data/sheets/template/debug_answer_list_partial.json
@@ -30,97 +30,129 @@
     {
       "name": "answer_list",
       "value": [
-        "name:option_1 | text: @local.answer_data.option_1.text | image: @local.answer_data.option_1.image_asset",
-        "name:option_2 | text: @local.answer_data.option_2.text | image: @local.answer_data.option_2.image_asset",
-        "name:option_3 | text: @local.answer_data.option_3.text | image: @local.answer_data.option_3.image_asset",
-        "name:option_4 | text: @local.answer_data.option_4.text | image: @local.answer_data.option_4.image_asset"
+        {
+          "name": "option_1",
+          "text": "@local.answer_data.option_1.text",
+          "image": "@local.answer_data.option_1.image_asset"
+        },
+        {
+          "name": "option_2",
+          "text": "@local.answer_data.option_2.text",
+          "image": "@local.answer_data.option_2.image_asset"
+        },
+        {
+          "name": "option_3",
+          "text": "@local.answer_data.option_3.text",
+          "image": "@local.answer_data.option_3.image_asset"
+        },
+        {
+          "name": "option_4",
+          "text": "@local.answer_data.option_4.text",
+          "image": "@local.answer_data.option_4.image_asset"
+        }
       ],
       "type": "set_variable",
       "_nested_name": "answer_list",
       "_dynamicFields": {
         "value": {
-          "0": [
-            {
-              "fullExpression": "name:option_1 | text: @local.answer_data.option_1.text | image: @local.answer_data.option_1.image_asset",
-              "matchedExpression": "@local.answer_data.option_1.text",
-              "type": "local",
-              "fieldName": "answer_data"
-            },
-            {
-              "fullExpression": "name:option_1 | text: @local.answer_data.option_1.text | image: @local.answer_data.option_1.image_asset",
-              "matchedExpression": "@local.answer_data.option_1.image_asset",
-              "type": "local",
-              "fieldName": "answer_data"
-            }
-          ],
-          "1": [
-            {
-              "fullExpression": "name:option_2 | text: @local.answer_data.option_2.text | image: @local.answer_data.option_2.image_asset",
-              "matchedExpression": "@local.answer_data.option_2.text",
-              "type": "local",
-              "fieldName": "answer_data"
-            },
-            {
-              "fullExpression": "name:option_2 | text: @local.answer_data.option_2.text | image: @local.answer_data.option_2.image_asset",
-              "matchedExpression": "@local.answer_data.option_2.image_asset",
-              "type": "local",
-              "fieldName": "answer_data"
-            }
-          ],
-          "2": [
-            {
-              "fullExpression": "name:option_3 | text: @local.answer_data.option_3.text | image: @local.answer_data.option_3.image_asset",
-              "matchedExpression": "@local.answer_data.option_3.text",
-              "type": "local",
-              "fieldName": "answer_data"
-            },
-            {
-              "fullExpression": "name:option_3 | text: @local.answer_data.option_3.text | image: @local.answer_data.option_3.image_asset",
-              "matchedExpression": "@local.answer_data.option_3.image_asset",
-              "type": "local",
-              "fieldName": "answer_data"
-            }
-          ],
-          "3": [
-            {
-              "fullExpression": "name:option_4 | text: @local.answer_data.option_4.text | image: @local.answer_data.option_4.image_asset",
-              "matchedExpression": "@local.answer_data.option_4.text",
-              "type": "local",
-              "fieldName": "answer_data"
-            },
-            {
-              "fullExpression": "name:option_4 | text: @local.answer_data.option_4.text | image: @local.answer_data.option_4.image_asset",
-              "matchedExpression": "@local.answer_data.option_4.image_asset",
-              "type": "local",
-              "fieldName": "answer_data"
-            }
-          ]
+          "0": {
+            "text": [
+              {
+                "fullExpression": "@local.answer_data.option_1.text",
+                "matchedExpression": "@local.answer_data.option_1.text",
+                "type": "local",
+                "fieldName": "answer_data"
+              }
+            ],
+            "image": [
+              {
+                "fullExpression": "@local.answer_data.option_1.image_asset",
+                "matchedExpression": "@local.answer_data.option_1.image_asset",
+                "type": "local",
+                "fieldName": "answer_data"
+              }
+            ]
+          },
+          "1": {
+            "text": [
+              {
+                "fullExpression": "@local.answer_data.option_2.text",
+                "matchedExpression": "@local.answer_data.option_2.text",
+                "type": "local",
+                "fieldName": "answer_data"
+              }
+            ],
+            "image": [
+              {
+                "fullExpression": "@local.answer_data.option_2.image_asset",
+                "matchedExpression": "@local.answer_data.option_2.image_asset",
+                "type": "local",
+                "fieldName": "answer_data"
+              }
+            ]
+          },
+          "2": {
+            "text": [
+              {
+                "fullExpression": "@local.answer_data.option_3.text",
+                "matchedExpression": "@local.answer_data.option_3.text",
+                "type": "local",
+                "fieldName": "answer_data"
+              }
+            ],
+            "image": [
+              {
+                "fullExpression": "@local.answer_data.option_3.image_asset",
+                "matchedExpression": "@local.answer_data.option_3.image_asset",
+                "type": "local",
+                "fieldName": "answer_data"
+              }
+            ]
+          },
+          "3": {
+            "text": [
+              {
+                "fullExpression": "@local.answer_data.option_4.text",
+                "matchedExpression": "@local.answer_data.option_4.text",
+                "type": "local",
+                "fieldName": "answer_data"
+              }
+            ],
+            "image": [
+              {
+                "fullExpression": "@local.answer_data.option_4.image_asset",
+                "matchedExpression": "@local.answer_data.option_4.image_asset",
+                "type": "local",
+                "fieldName": "answer_data"
+              }
+            ]
+          }
         }
       },
       "_dynamicDependencies": {
         "@local.answer_data.option_1.text": [
-          "value.0"
+          "value.0.text"
         ],
         "@local.answer_data.option_1.image_asset": [
-          "value.0"
+          "value.0.image"
         ],
         "@local.answer_data.option_2.text": [
-          "value.1"
+          "value.1.text"
         ],
         "@local.answer_data.option_2.image_asset": [
-          "value.1"
+          "value.1.image"
         ],
         "@local.answer_data.option_3.text": [
-          "value.2"
+          "value.2.text"
         ],
         "@local.answer_data.option_3.image_asset": [
-          "value.2"
+          "value.2.image"
         ],
         "@local.answer_data.option_4.text": [
-          "value.3"
+          "value.3.text"
         ],
         "@local.answer_data.option_4.image_asset": [
-          "value.3"
+          "value.3.image"
         ]
       }
     },
@@ -130,8 +162,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "title",
-      "_nested_name": "title"
+      "name": "title_4",
+      "_nested_name": "title_4"
     },
     {
       "type": "combo_box",
@@ -140,8 +172,8 @@
         "answer_list": "@local.answer_list",
         "placeholder": "Tap and choose"
       },
-      "name": "combo_box",
-      "_nested_name": "combo_box",
+      "name": "combo_box_5",
+      "_nested_name": "combo_box_5",
       "_dynamicFields": {
         "parameter_list": {
           "answer_list": [
@@ -166,16 +198,16 @@
       "_translations": {
         "value": {}
       },
-      "name": "title",
-      "_nested_name": "title"
+      "name": "title_6",
+      "_nested_name": "title_6"
     },
     {
       "type": "radio_button_grid",
       "parameter_list": {
         "answer_list": "@local.answer_list"
       },
-      "name": "radio_button_grid",
-      "_nested_name": "radio_button_grid",
+      "name": "radio_button_grid_7",
+      "_nested_name": "radio_button_grid_7",
       "_dynamicFields": {
         "parameter_list": {
           "answer_list": [
@@ -200,16 +232,16 @@
       "_translations": {
         "value": {}
       },
-      "name": "title",
-      "_nested_name": "title"
+      "name": "title_8",
+      "_nested_name": "title_8"
     },
     {
       "type": "radio_group",
       "parameter_list": {
         "answer_list": "@local.answer_list"
       },
-      "name": "radio_group",
-      "_nested_name": "radio_group",
+      "name": "radio_group_9",
+      "_nested_name": "radio_group_9",
       "_dynamicFields": {
         "parameter_list": {
           "answer_list": [

--- a/app_data/sheets/template/debug_data_items_r_template.json
+++ b/app_data/sheets/template/debug_data_items_r_template.json
@@ -9,8 +9,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "title",
-      "_nested_name": "title"
+      "name": "title_2",
+      "_nested_name": "title_2"
     }
   ],
   "_xlsxPath": "debug_sheets/debug_data_items_nested_template.xlsx"

--- a/app_data/sheets/template/debug_data_items_rendering.json
+++ b/app_data/sheets/template/debug_data_items_rendering.json
@@ -21,11 +21,11 @@
           "name": "debug_data_items_r_template",
           "value": "debug_data_items_r_template",
           "rows": [],
-          "_nested_name": "data_items.debug_data_items_r_template"
+          "_nested_name": "data_items_3.debug_data_items_r_template"
         }
       ],
-      "name": "data_items",
-      "_nested_name": "data_items",
+      "name": "data_items_3",
+      "_nested_name": "data_items_3",
       "_dynamicFields": {
         "value": [
           {

--- a/app_data/sheets/template/debug_example.json
+++ b/app_data/sheets/template/debug_example.json
@@ -18,8 +18,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "text",
-      "_nested_name": "text"
+      "name": "text_3",
+      "_nested_name": "text_3"
     },
     {
       "type": "text",
@@ -27,8 +27,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "text",
-      "_nested_name": "text"
+      "name": "text_4",
+      "_nested_name": "text_4"
     },
     {
       "type": "toggle_bar",

--- a/app_data/sheets/template/debug_long_link_dashed_box.json
+++ b/app_data/sheets/template/debug_long_link_dashed_box.json
@@ -28,8 +28,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "dashed_box",
-      "_nested_name": "dashed_box"
+      "name": "dashed_box_4",
+      "_nested_name": "dashed_box_4"
     }
   ],
   "_xlsxPath": "debug_sheets/debug_hyperlinks.xlsx"

--- a/app_data/sheets/template/debug_nav_bar.json
+++ b/app_data/sheets/template/debug_nav_bar.json
@@ -6,9 +6,18 @@
     {
       "name": "button_list",
       "value": [
-        "image: images/icons/globe_blue.svg | target_template: home_screen",
-        "image: images/icons/heart_blue.svg | target_template: example_dg",
-        "image: images/icons/school_blue.svg | target_template: example_calc"
+        {
+          "image": "images/icons/globe_blue.svg",
+          "target_template": "home_screen"
+        },
+        {
+          "image": "images/icons/heart_blue.svg",
+          "target_template": "example_dg"
+        },
+        {
+          "image": "images/icons/school_blue.svg",
+          "target_template": "example_calc"
+        }
       ],
       "type": "set_variable",
       "_nested_name": "button_list"
@@ -40,26 +49,25 @@
     },
     {
       "name": "button_list_data",
-      "value": [
-        "@data.debug_nav_bar_data"
-      ],
+      "value": "@data.debug_nav_bar_data",
+      "_translations": {
+        "value": {}
+      },
       "type": "set_variable",
       "_nested_name": "button_list_data",
       "_dynamicFields": {
-        "value": {
-          "0": [
-            {
-              "fullExpression": "@data.debug_nav_bar_data",
-              "matchedExpression": "@data.debug_nav_bar_data",
-              "type": "data",
-              "fieldName": "debug_nav_bar_data"
-            }
-          ]
-        }
+        "value": [
+          {
+            "fullExpression": "@data.debug_nav_bar_data",
+            "matchedExpression": "@data.debug_nav_bar_data",
+            "type": "data",
+            "fieldName": "debug_nav_bar_data"
+          }
+        ]
       },
       "_dynamicDependencies": {
         "@data.debug_nav_bar_data": [
-          "value.0"
+          "value"
         ]
       }
     },

--- a/app_data/sheets/template/debug_sync_id.json
+++ b/app_data/sheets/template/debug_sync_id.json
@@ -107,8 +107,8 @@
           "_translations": {
             "value": {}
           },
-          "name": "qr_code",
-          "_nested_name": "has_ever_been_synced.qr_code",
+          "name": "qr_code_1",
+          "_nested_name": "has_ever_been_synced.qr_code_1",
           "_dynamicFields": {
             "value": [
               {

--- a/app_data/sheets/template/example_generator/example_generator_output_w_1.json
+++ b/app_data/sheets/template/example_generator/example_generator_output_w_1.json
@@ -48,7 +48,7 @@
           "_translations": {
             "value": {}
           },
-          "_nested_name": "items.text_@item.id",
+          "_nested_name": "items_4.text_@item.id",
           "_dynamicFields": {
             "name": [
               {
@@ -68,7 +68,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "items.text_@item.id",
+                "fullExpression": "items_4.text_@item.id",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -86,8 +86,8 @@
           }
         }
       ],
-      "name": "items",
-      "_nested_name": "items",
+      "name": "items_4",
+      "_nested_name": "items_4",
       "_dynamicFields": {
         "value": [
           {

--- a/app_data/sheets/template/example_generator/example_generator_output_w_2.json
+++ b/app_data/sheets/template/example_generator/example_generator_output_w_2.json
@@ -33,7 +33,7 @@
           "_translations": {
             "value": {}
           },
-          "_nested_name": "items.text_@item.id",
+          "_nested_name": "items_4.text_@item.id",
           "_dynamicFields": {
             "name": [
               {
@@ -53,7 +53,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "items.text_@item.id",
+                "fullExpression": "items_4.text_@item.id",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -71,8 +71,8 @@
           }
         }
       ],
-      "name": "items",
-      "_nested_name": "items",
+      "name": "items_4",
+      "_nested_name": "items_4",
       "_dynamicFields": {
         "value": [
           {

--- a/app_data/sheets/template/example_list_override/example_list_override.json
+++ b/app_data/sheets/template/example_list_override/example_list_override.json
@@ -58,9 +58,10 @@
     {
       "type": "button",
       "name": "set_list_1",
-      "value": [
-        "Set List 1"
-      ],
+      "value": "Set List 1",
+      "_translations": {
+        "value": {}
+      },
       "action_list": [
         {
           "trigger": "click",
@@ -88,26 +89,25 @@
     {
       "type": "text",
       "name": "selected_list",
-      "value": [
-        "Selected List: @fields.example_list_override_field"
-      ],
+      "value": "Selected List: @fields.example_list_override_field",
+      "_translations": {
+        "value": {}
+      },
       "exclude_from_translation": true,
       "_nested_name": "selected_list",
       "_dynamicFields": {
-        "value": {
-          "0": [
-            {
-              "fullExpression": "Selected List: @fields.example_list_override_field",
-              "matchedExpression": "@fields.example_list_override_field",
-              "type": "fields",
-              "fieldName": "example_list_override_field"
-            }
-          ]
-        }
+        "value": [
+          {
+            "fullExpression": "Selected List: @fields.example_list_override_field",
+            "matchedExpression": "@fields.example_list_override_field",
+            "type": "fields",
+            "fieldName": "example_list_override_field"
+          }
+        ]
       },
       "_dynamicDependencies": {
         "@fields.example_list_override_field": [
-          "value.0"
+          "value"
         ]
       }
     },
@@ -130,7 +130,7 @@
             "value": {}
           },
           "exclude_from_translation": true,
-          "_nested_name": "items.result_text_@item.id",
+          "_nested_name": "items_8.result_text_@item.id",
           "_dynamicFields": {
             "name": [
               {
@@ -150,7 +150,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "items.result_text_@item.id",
+                "fullExpression": "items_8.result_text_@item.id",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -168,8 +168,8 @@
           }
         }
       ],
-      "name": "items",
-      "_nested_name": "items",
+      "name": "items_8",
+      "_nested_name": "items_8",
       "_dynamicFields": {
         "value": [
           {

--- a/app_data/sheets/template/feat_footer.json
+++ b/app_data/sheets/template/feat_footer.json
@@ -6,9 +6,18 @@
     {
       "name": "button_list",
       "value": [
-        "image: images/icons/house_white.svg | target_template: home_screen",
-        "image: images/icons/star_white.svg | target_template: comp_button",
-        "image: images/icons/book_white.svg | target_template: comp_button"
+        {
+          "image": "images/icons/house_white.svg",
+          "target_template": "home_screen"
+        },
+        {
+          "image": "images/icons/star_white.svg",
+          "target_template": "comp_button"
+        },
+        {
+          "image": "images/icons/book_white.svg",
+          "target_template": "comp_button"
+        }
       ],
       "type": "set_variable",
       "_nested_name": "button_list"
@@ -18,8 +27,8 @@
       "parameter_list": {
         "button_list": "@local.button_list"
       },
-      "name": "navigation_bar",
-      "_nested_name": "navigation_bar",
+      "name": "navigation_bar_3",
+      "_nested_name": "navigation_bar_3",
       "_dynamicFields": {
         "parameter_list": {
           "button_list": [

--- a/app_data/sheets/template/feat_task_group_subtask_toggle.json
+++ b/app_data/sheets/template/feat_task_group_subtask_toggle.json
@@ -18,8 +18,8 @@
           "_translations": {
             "value": {}
           },
-          "name": "text",
-          "_nested_name": "items.text",
+          "name": "text_1",
+          "_nested_name": "items_3.text_1",
           "_dynamicFields": {
             "value": [
               {
@@ -63,7 +63,7 @@
               "_cleaned": "changed | emit: force_reload"
             }
           ],
-          "_nested_name": "items.toggle_bar_@item.id",
+          "_nested_name": "items_3.toggle_bar_@item.id",
           "_dynamicFields": {
             "name": [
               {
@@ -113,7 +113,7 @@
             },
             "_nested_name": [
               {
-                "fullExpression": "items.toggle_bar_@item.id",
+                "fullExpression": "items_3.toggle_bar_@item.id",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -134,8 +134,8 @@
           }
         }
       ],
-      "name": "items",
-      "_nested_name": "items",
+      "name": "items_3",
+      "_nested_name": "items_3",
       "_dynamicFields": {
         "value": [
           {

--- a/app_data/sheets/template/feature_feedback_debug.json
+++ b/app_data/sheets/template/feature_feedback_debug.json
@@ -11,8 +11,8 @@
         "value": {}
       },
       "exclude_from_translation": true,
-      "name": "title",
-      "_nested_name": "title"
+      "name": "title_2",
+      "_nested_name": "title_2"
     },
     {
       "type": "text",
@@ -21,8 +21,8 @@
         "value": {}
       },
       "exclude_from_translation": true,
-      "name": "text",
-      "_nested_name": "text",
+      "name": "text_3",
+      "_nested_name": "text_3",
       "_dynamicFields": {
         "value": [
           {
@@ -46,8 +46,8 @@
         "value": {}
       },
       "exclude_from_translation": true,
-      "name": "text",
-      "_nested_name": "text",
+      "name": "text_4",
+      "_nested_name": "text_4",
       "_dynamicFields": {
         "value": [
           {
@@ -71,8 +71,8 @@
         "value": {}
       },
       "exclude_from_translation": true,
-      "name": "title",
-      "_nested_name": "title"
+      "name": "title_5",
+      "_nested_name": "title_5"
     },
     {
       "type": "button",
@@ -102,8 +102,8 @@
       ],
       "condition": "!@fields._feedback_sidebar_open",
       "exclude_from_translation": true,
-      "name": "button",
-      "_nested_name": "button",
+      "name": "button_6",
+      "_nested_name": "button_6",
       "_dynamicFields": {
         "condition": [
           {
@@ -148,8 +148,8 @@
       ],
       "condition": "@fields._feedback_sidebar_open",
       "exclude_from_translation": true,
-      "name": "button",
-      "_nested_name": "button",
+      "name": "button_7",
+      "_nested_name": "button_7",
       "_dynamicFields": {
         "condition": [
           {
@@ -185,8 +185,8 @@
         }
       ],
       "exclude_from_translation": true,
-      "name": "button",
-      "_nested_name": "button"
+      "name": "button_8",
+      "_nested_name": "button_8"
     },
     {
       "type": "button",
@@ -207,8 +207,8 @@
         }
       ],
       "exclude_from_translation": true,
-      "name": "button",
-      "_nested_name": "button"
+      "name": "button_9",
+      "_nested_name": "button_9"
     },
     {
       "type": "button",
@@ -228,8 +228,8 @@
         }
       ],
       "exclude_from_translation": true,
-      "name": "button",
-      "_nested_name": "button"
+      "name": "button_10",
+      "_nested_name": "button_10"
     },
     {
       "type": "button",
@@ -249,8 +249,8 @@
         }
       ],
       "exclude_from_translation": true,
-      "name": "button",
-      "_nested_name": "button"
+      "name": "button_11",
+      "_nested_name": "button_11"
     },
     {
       "type": "button",
@@ -271,8 +271,8 @@
         }
       ],
       "exclude_from_translation": true,
-      "name": "button",
-      "_nested_name": "button"
+      "name": "button_12",
+      "_nested_name": "button_12"
     }
   ],
   "_xlsxPath": "feature_sheets/to_be_sorted/feature_feedback.xlsx"

--- a/app_data/sheets/template/feature_save_open_file.json
+++ b/app_data/sheets/template/feature_save_open_file.json
@@ -9,8 +9,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "title",
-      "_nested_name": "title"
+      "name": "title_2",
+      "_nested_name": "title_2"
     },
     {
       "type": "subtitle",
@@ -18,8 +18,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "subtitle",
-      "_nested_name": "subtitle"
+      "name": "subtitle_3",
+      "_nested_name": "subtitle_3"
     },
     {
       "name": "image_path",
@@ -36,8 +36,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "text",
-      "_nested_name": "text",
+      "name": "text_5",
+      "_nested_name": "text_5",
       "_dynamicFields": {
         "value": [
           {
@@ -60,8 +60,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "image",
-      "_nested_name": "image",
+      "name": "image_6",
+      "_nested_name": "image_6",
       "_dynamicFields": {
         "value": [
           {
@@ -202,8 +202,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "subtitle",
-      "_nested_name": "subtitle"
+      "name": "subtitle_9",
+      "_nested_name": "subtitle_9"
     },
     {
       "name": "pdf_path",
@@ -220,8 +220,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "text",
-      "_nested_name": "text",
+      "name": "text_11",
+      "_nested_name": "text_11",
       "_dynamicFields": {
         "value": [
           {

--- a/app_data/sheets/template/feature_set_theme.json
+++ b/app_data/sheets/template/feature_set_theme.json
@@ -9,14 +9,20 @@
       "_translations": {
         "value": {}
       },
-      "name": "title",
-      "_nested_name": "title"
+      "name": "title_2",
+      "_nested_name": "title_2"
     },
     {
       "name": "theme_list",
       "value": [
-        "name: default | text: default",
-        "name: professional | text: professional"
+        {
+          "name": "default",
+          "text": "default"
+        },
+        {
+          "name": "professional",
+          "text": "professional"
+        }
       ],
       "type": "set_variable",
       "_nested_name": "theme_list"

--- a/app_data/sheets/template/feature_share.json
+++ b/app_data/sheets/template/feature_share.json
@@ -9,8 +9,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "title",
-      "_nested_name": "title"
+      "name": "title_2",
+      "_nested_name": "title_2"
     },
     {
       "name": "shareable_text",
@@ -36,8 +36,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "text",
-      "_nested_name": "text",
+      "name": "text_5",
+      "_nested_name": "text_5",
       "_dynamicFields": {
         "value": [
           {
@@ -120,8 +120,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "title",
-      "_nested_name": "title"
+      "name": "title_7",
+      "_nested_name": "title_7"
     },
     {
       "type": "text",
@@ -129,8 +129,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "text",
-      "_nested_name": "text"
+      "name": "text_8",
+      "_nested_name": "text_8"
     },
     {
       "type": "button",
@@ -198,8 +198,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "title",
-      "_nested_name": "title"
+      "name": "title_10",
+      "_nested_name": "title_10"
     },
     {
       "type": "select_text",
@@ -280,8 +280,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "title",
-      "_nested_name": "title"
+      "name": "title_12",
+      "_nested_name": "title_12"
     },
     {
       "type": "button",

--- a/app_data/sheets/template/feature_share_file.json
+++ b/app_data/sheets/template/feature_share_file.json
@@ -9,8 +9,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "title",
-      "_nested_name": "title"
+      "name": "title_2",
+      "_nested_name": "title_2"
     },
     {
       "type": "subtitle",
@@ -18,8 +18,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "subtitle",
-      "_nested_name": "subtitle"
+      "name": "subtitle_3",
+      "_nested_name": "subtitle_3"
     },
     {
       "name": "image_path",
@@ -36,8 +36,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "text",
-      "_nested_name": "text",
+      "name": "text_5",
+      "_nested_name": "text_5",
       "_dynamicFields": {
         "value": [
           {
@@ -60,8 +60,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "image",
-      "_nested_name": "image",
+      "name": "image_6",
+      "_nested_name": "image_6",
       "_dynamicFields": {
         "value": [
           {
@@ -144,8 +144,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "subtitle",
-      "_nested_name": "subtitle"
+      "name": "subtitle_8",
+      "_nested_name": "subtitle_8"
     },
     {
       "name": "pdf_path",

--- a/app_data/sheets/template/feature_task_group.json
+++ b/app_data/sheets/template/feature_task_group.json
@@ -9,8 +9,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "title",
-      "_nested_name": "title"
+      "name": "title_2",
+      "_nested_name": "title_2"
     },
     {
       "name": "task_groups_data",
@@ -56,8 +56,8 @@
                 "in_progress_icon": "images/icons/in_progress.svg",
                 "completed_icon": "images/icons/tick_white.svg"
               },
-              "name": "task_card",
-              "_nested_name": "carousel.items.task_card",
+              "name": "task_card_1",
+              "_nested_name": "carousel_4.items_1.task_card_1",
               "_dynamicFields": {
                 "parameter_list": {
                   "task_group_id": [
@@ -132,8 +132,8 @@
               }
             }
           ],
-          "name": "items",
-          "_nested_name": "carousel.items",
+          "name": "items_1",
+          "_nested_name": "carousel_4.items_1",
           "_dynamicFields": {
             "value": [
               {
@@ -151,8 +151,8 @@
           }
         }
       ],
-      "name": "carousel",
-      "_nested_name": "carousel",
+      "name": "carousel_4",
+      "_nested_name": "carousel_4",
       "_dynamicFields": {
         "parameter_list": {
           "task_group_data": [
@@ -196,8 +196,8 @@
                   "_translations": {
                     "value": {}
                   },
-                  "name": "text",
-                  "_nested_name": "grid_1.items.display_group.text",
+                  "name": "text_1",
+                  "_nested_name": "grid_1.items_1.display_group_1.text_1",
                   "_dynamicFields": {
                     "value": [
                       {
@@ -225,7 +225,7 @@
                         "value": {}
                       },
                       "type": "set_variable",
-                      "_nested_name": "grid_1.items.display_group.feat_task_group_subtask_toggle.task_group_data",
+                      "_nested_name": "grid_1.items_1.display_group_1.feat_task_group_subtask_toggle.task_group_data",
                       "_dynamicFields": {
                         "value": [
                           {
@@ -244,15 +244,15 @@
                     }
                   ],
                   "name": "feat_task_group_subtask_toggle",
-                  "_nested_name": "grid_1.items.display_group.feat_task_group_subtask_toggle"
+                  "_nested_name": "grid_1.items_1.display_group_1.feat_task_group_subtask_toggle"
                 }
               ],
-              "name": "display_group",
-              "_nested_name": "grid_1.items.display_group"
+              "name": "display_group_1",
+              "_nested_name": "grid_1.items_1.display_group_1"
             }
           ],
-          "name": "items",
-          "_nested_name": "grid_1.items",
+          "name": "items_1",
+          "_nested_name": "grid_1.items_1",
           "_dynamicFields": {
             "value": [
               {

--- a/config.ts
+++ b/config.ts
@@ -14,7 +14,7 @@ config.web.favicon_asset = "images/icons/favicon.svg";
 
 config.git = {
   content_repo: "https://github.com/IDEMSInternational/app-debug-content.git",
-  content_tag_latest: "1.2.20",
+  content_tag_latest: "1.2.24",
 };
 
 config.app_config.ASSET_PACKS = {


### PR DESCRIPTION
Replaces #63 – attempt to create a Firebase preview link that isn't marked as dangerous by Chrome (see discussion on that PR).

> Notably, this includes the changes made to the parsed sheets by the latest version of the template parser, updated in https://github.com/IDEMSInternational/parenting-app-ui/pull/2211 to parse answer lists and to add auto-generated names to rows that do not specify their own.