### PR TITLE
content: 1.2.29

### DIFF
--- a/app_data/sheets/contents.json
+++ b/app_data/sheets/contents.json
@@ -1056,6 +1056,12 @@
       "flow_subtype": "debug",
       "_xlsxPath": "debug_sheets/debug_data_items.xlsx"
     },
+    "debug_data_items_list": {
+      "flow_type": "template",
+      "flow_name": "debug_data_items_list",
+      "flow_subtype": "debug",
+      "_xlsxPath": "debug_sheets/debug_data_items.xlsx"
+    },
     "debug_data_items_nesting": {
       "flow_type": "template",
       "flow_name": "debug_data_items_nesting",

--- a/app_data/sheets/contents.json
+++ b/app_data/sheets/contents.json
@@ -1308,6 +1308,12 @@
       "flow_subtype": "debug",
       "_xlsxPath": "debug_sheets/to_be_sorted/debug_items.xlsx"
     },
+    "debug_kids": {
+      "flow_type": "template",
+      "flow_name": "debug_kids",
+      "flow_subtype": "debug",
+      "_xlsxPath": "debug_sheets/debug_data_items.xlsx"
+    },
     "debug_lang_global_1": {
       "flow_type": "template",
       "flow_name": "debug_lang_global_1",
@@ -2863,6 +2869,11 @@
       "flow_name": "feature_feedback_text_select",
       "comments": "Default text-select feedback form",
       "_xlsxPath": "feature_sheets/to_be_sorted/feature_feedback.xlsx"
+    },
+    "feature_rtl_language": {
+      "flow_type": "template",
+      "flow_name": "feature_rtl_language",
+      "_xlsxPath": "feature_sheets/feature_rtl_language.xlsx"
     },
     "feature_save_open_file": {
       "flow_type": "template",

--- a/app_data/sheets/data_list/component_demo/comp_data_items_list.json
+++ b/app_data/sheets/data_list/component_demo/comp_data_items_list.json
@@ -7,17 +7,20 @@
     {
       "id": "id_1",
       "label": "Task 1",
-      "completed": false
+      "completed": false,
+      "type": "type_a"
     },
     {
       "id": "id_2",
       "label": "Task 2",
-      "completed": true
+      "completed": true,
+      "type": "type_b"
     },
     {
       "id": "id_3",
       "label": "Task 3",
-      "completed": true
+      "completed": true,
+      "type": "type_b"
     }
   ],
   "_xlsxPath": "component_sheets/component_data_items.xlsx"

--- a/app_data/sheets/data_list/debug/debug_data_list_order.json
+++ b/app_data/sheets/data_list/debug/debug_data_list_order.json
@@ -11,7 +11,8 @@
       "id": "item_2"
     },
     {
-      "id": "item_10"
+      "id": "item_10",
+      "property": "A value"
     },
     {
       "id": "item_a"

--- a/app_data/sheets/data_list/generated/example_pipe_appended.json
+++ b/app_data/sheets/data_list/generated/example_pipe_appended.json
@@ -10,7 +10,9 @@
       "sort_alpha": "bonus",
       "completed": true,
       "Text": "Hello id_1",
-      "Boolean": "FALSE"
+      "Boolean": false,
+      "number": -5.25,
+      "number_text": "-5.25"
     },
     {
       "id": "id_2",
@@ -19,7 +21,9 @@
       "sort_alpha": "basis",
       "completed": false,
       "Text": "Hello id_2",
-      "Boolean": "FALSE"
+      "Boolean": false,
+      "number": -5.25,
+      "number_text": "-5.25"
     },
     {
       "id": "id_3",
@@ -27,7 +31,9 @@
       "sort_order": 6,
       "sort_alpha": "topic",
       "Text": "Hello id_3",
-      "Boolean": "FALSE"
+      "Boolean": false,
+      "number": -5.25,
+      "number_text": "-5.25"
     },
     {
       "id": "id_4",
@@ -35,7 +41,9 @@
       "sort_order": 5,
       "sort_alpha": "world",
       "Text": "Hello id_4",
-      "Boolean": "FALSE"
+      "Boolean": false,
+      "number": -5.25,
+      "number_text": "-5.25"
     },
     {
       "id": "id_5",
@@ -44,7 +52,9 @@
       "sort_alpha": "event",
       "completed": true,
       "Text": "Hello id_5",
-      "Boolean": "FALSE"
+      "Boolean": false,
+      "number": -5.25,
+      "number_text": "-5.25"
     },
     {
       "id": "id_6",
@@ -53,7 +63,9 @@
       "sort_alpha": "photo",
       "completed": true,
       "Text": "Hello id_6",
-      "Boolean": "FALSE"
+      "Boolean": false,
+      "number": -5.25,
+      "number_text": "-5.25"
     },
     {
       "id": "id_7",
@@ -62,7 +74,9 @@
       "sort_alpha": "guest",
       "completed": false,
       "Text": "Hello id_7",
-      "Boolean": "FALSE"
+      "Boolean": false,
+      "number": -5.25,
+      "number_text": "-5.25"
     },
     {
       "id": "id_8",
@@ -71,7 +85,9 @@
       "sort_alpha": "skill",
       "completed": false,
       "Text": "Hello id_8",
-      "Boolean": "FALSE"
+      "Boolean": false,
+      "number": -5.25,
+      "number_text": "-5.25"
     }
   ]
 }

--- a/app_data/sheets/data_pipe/example_pipe/example_data_pipe_append.json
+++ b/app_data/sheets/data_pipe/example_pipe/example_data_pipe_append.json
@@ -8,7 +8,9 @@
       "operation": "append_columns",
       "args_list": [
         "Text: Hello {@row.id}",
-        "Boolean: FALSE"
+        "Boolean: FALSE",
+        "number: -5.25",
+        "number_text: \"-5.25\""
       ],
       "input_source": "example_data_pipe_list",
       "output_target": "example_pipe_appended"

--- a/app_data/sheets/template/debug/debug_data_items.json
+++ b/app_data/sheets/template/debug/debug_data_items.json
@@ -48,6 +48,7 @@
     },
     {
       "type": "data_items",
+      "name": "data_items",
       "value": "@data.comp_data_items_list",
       "rows": [
         {
@@ -57,7 +58,7 @@
           "_translations": {
             "value": {}
           },
-          "_nested_name": "data_items_5.id_@item.id",
+          "_nested_name": "data_items.id_@item.id",
           "_dynamicFields": {
             "name": [
               {
@@ -77,7 +78,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "data_items_5.id_@item.id",
+                "fullExpression": "data_items.id_@item.id",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -99,7 +100,7 @@
           "_translations": {
             "value": {}
           },
-          "_nested_name": "data_items_5.text_@item.id",
+          "_nested_name": "data_items.text_@item.id",
           "_dynamicFields": {
             "name": [
               {
@@ -119,7 +120,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "data_items_5.text_@item.id",
+                "fullExpression": "data_items.text_@item.id",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -135,10 +136,144 @@
               "value"
             ]
           }
+        },
+        {
+          "type": "display_group",
+          "name": "dg_@item.id",
+          "rows": [
+            {
+              "type": "text",
+              "name": "dg_id_@item.id",
+              "value": "Item ID: @item.id",
+              "_translations": {
+                "value": {}
+              },
+              "_nested_name": "data_items.dg_@item.id.dg_id_@item.id",
+              "_dynamicFields": {
+                "name": [
+                  {
+                    "fullExpression": "dg_id_@item.id",
+                    "matchedExpression": "@item.id",
+                    "type": "item",
+                    "fieldName": "id"
+                  }
+                ],
+                "value": [
+                  {
+                    "fullExpression": "Item ID: @item.id",
+                    "matchedExpression": "@item.id",
+                    "type": "item",
+                    "fieldName": "id"
+                  }
+                ],
+                "_nested_name": [
+                  {
+                    "fullExpression": "data_items.dg_@item.id.dg_id_@item.id",
+                    "matchedExpression": "@item.id.dg_id_",
+                    "type": "item",
+                    "fieldName": "id"
+                  },
+                  {
+                    "fullExpression": "data_items.dg_@item.id.dg_id_@item.id",
+                    "matchedExpression": "@item.id",
+                    "type": "item",
+                    "fieldName": "id"
+                  }
+                ]
+              },
+              "_dynamicDependencies": {
+                "@item.id": [
+                  "name",
+                  "value",
+                  "_nested_name"
+                ],
+                "@item.id.dg_id_": [
+                  "_nested_name"
+                ]
+              }
+            },
+            {
+              "type": "text",
+              "name": "dg_text_@item.id",
+              "value": "local_1 value: @local.local_1",
+              "_translations": {
+                "value": {}
+              },
+              "_nested_name": "data_items.dg_@item.id.dg_text_@item.id",
+              "_dynamicFields": {
+                "name": [
+                  {
+                    "fullExpression": "dg_text_@item.id",
+                    "matchedExpression": "@item.id",
+                    "type": "item",
+                    "fieldName": "id"
+                  }
+                ],
+                "value": [
+                  {
+                    "fullExpression": "local_1 value: @local.local_1",
+                    "matchedExpression": "@local.local_1",
+                    "type": "local",
+                    "fieldName": "local_1"
+                  }
+                ],
+                "_nested_name": [
+                  {
+                    "fullExpression": "data_items.dg_@item.id.dg_text_@item.id",
+                    "matchedExpression": "@item.id.dg_text_",
+                    "type": "item",
+                    "fieldName": "id"
+                  },
+                  {
+                    "fullExpression": "data_items.dg_@item.id.dg_text_@item.id",
+                    "matchedExpression": "@item.id",
+                    "type": "item",
+                    "fieldName": "id"
+                  }
+                ]
+              },
+              "_dynamicDependencies": {
+                "@item.id": [
+                  "name",
+                  "_nested_name"
+                ],
+                "@local.local_1": [
+                  "value"
+                ],
+                "@item.id.dg_text_": [
+                  "_nested_name"
+                ]
+              }
+            }
+          ],
+          "_nested_name": "data_items.dg_@item.id",
+          "_dynamicFields": {
+            "name": [
+              {
+                "fullExpression": "dg_@item.id",
+                "matchedExpression": "@item.id",
+                "type": "item",
+                "fieldName": "id"
+              }
+            ],
+            "_nested_name": [
+              {
+                "fullExpression": "data_items.dg_@item.id",
+                "matchedExpression": "@item.id",
+                "type": "item",
+                "fieldName": "id"
+              }
+            ]
+          },
+          "_dynamicDependencies": {
+            "@item.id": [
+              "name",
+              "_nested_name"
+            ]
+          }
         }
       ],
-      "name": "data_items_5",
-      "_nested_name": "data_items_5",
+      "_nested_name": "data_items",
       "_dynamicFields": {
         "value": [
           {

--- a/app_data/sheets/template/debug/debug_data_items_actions.json
+++ b/app_data/sheets/template/debug/debug_data_items_actions.json
@@ -5,13 +5,46 @@
   "flow_subtype": "debug",
   "rows": [
     {
+      "name": "local_var",
+      "value": "original_value",
+      "_translations": {
+        "value": {}
+      },
+      "type": "set_variable",
+      "_nested_name": "local_var"
+    },
+    {
+      "type": "text",
+      "name": "text",
+      "value": "Value of local variable: @local.local_var",
+      "_translations": {
+        "value": {}
+      },
+      "_nested_name": "text",
+      "_dynamicFields": {
+        "value": [
+          {
+            "fullExpression": "Value of local variable: @local.local_var",
+            "matchedExpression": "@local.local_var",
+            "type": "local",
+            "fieldName": "local_var"
+          }
+        ]
+      },
+      "_dynamicDependencies": {
+        "@local.local_var": [
+          "value"
+        ]
+      }
+    },
+    {
       "type": "title",
       "value": "Data items actions - no nesting",
       "_translations": {
         "value": {}
       },
-      "name": "title_2",
-      "_nested_name": "title_2"
+      "name": "title_4",
+      "_nested_name": "title_4"
     },
     {
       "type": "data_items",
@@ -24,7 +57,7 @@
             "value": {}
           },
           "name": "text_1",
-          "_nested_name": "data_items_3.text_1",
+          "_nested_name": "data_items_5.text_1",
           "_dynamicFields": {
             "value": [
               {
@@ -60,7 +93,7 @@
             }
           ],
           "name": "button_2",
-          "_nested_name": "data_items_3.button_2",
+          "_nested_name": "data_items_5.button_2",
           "_dynamicFields": {
             "action_list": {
               "0": {
@@ -100,10 +133,31 @@
               "action_list.0.params.completed"
             ]
           }
+        },
+        {
+          "type": "button",
+          "value": "Set local",
+          "_translations": {
+            "value": {}
+          },
+          "action_list": [
+            {
+              "trigger": "click",
+              "action_id": "set_local",
+              "args": [
+                "local_var",
+                "new_value"
+              ],
+              "_raw": "click | set_local: local_var: new_value",
+              "_cleaned": "click | set_local: local_var: new_value"
+            }
+          ],
+          "name": "button_3",
+          "_nested_name": "data_items_5.button_3"
         }
       ],
-      "name": "data_items_3",
-      "_nested_name": "data_items_3",
+      "name": "data_items_5",
+      "_nested_name": "data_items_5",
       "_dynamicFields": {
         "value": [
           {
@@ -126,8 +180,8 @@
       "_translations": {
         "value": {}
       },
-      "name": "title_5",
-      "_nested_name": "title_5"
+      "name": "title_7",
+      "_nested_name": "title_7"
     },
     {
       "type": "data_items",
@@ -140,7 +194,7 @@
             "value": {}
           },
           "name": "text_1",
-          "_nested_name": "data_items_6.text_1",
+          "_nested_name": "data_items_8.text_1",
           "_dynamicFields": {
             "value": [
               {
@@ -179,7 +233,7 @@
                 }
               ],
               "name": "button_1",
-              "_nested_name": "data_items_6.display_group_2.button_1",
+              "_nested_name": "data_items_8.display_group_2.button_1",
               "_dynamicFields": {
                 "action_list": {
                   "0": {
@@ -219,14 +273,35 @@
                   "action_list.0.params.completed"
                 ]
               }
+            },
+            {
+              "type": "button",
+              "value": "Set local",
+              "_translations": {
+                "value": {}
+              },
+              "action_list": [
+                {
+                  "trigger": "click",
+                  "action_id": "set_local",
+                  "args": [
+                    "local_var",
+                    "new_value"
+                  ],
+                  "_raw": "click | set_local: local_var: new_value",
+                  "_cleaned": "click | set_local: local_var: new_value"
+                }
+              ],
+              "name": "button_2",
+              "_nested_name": "data_items_8.display_group_2.button_2"
             }
           ],
           "name": "display_group_2",
-          "_nested_name": "data_items_6.display_group_2"
+          "_nested_name": "data_items_8.display_group_2"
         }
       ],
-      "name": "data_items_6",
-      "_nested_name": "data_items_6",
+      "name": "data_items_8",
+      "_nested_name": "data_items_8",
       "_dynamicFields": {
         "value": [
           {

--- a/app_data/sheets/template/debug/debug_data_items_list.json
+++ b/app_data/sheets/template/debug/debug_data_items_list.json
@@ -1,0 +1,670 @@
+{
+  "flow_type": "template",
+  "flow_name": "debug_data_items_list",
+  "status": "released",
+  "flow_subtype": "debug",
+  "rows": [
+    {
+      "type": "title",
+      "name": "title",
+      "value": "Looping over list specified in local variable",
+      "_translations": {
+        "value": {}
+      },
+      "_nested_name": "title"
+    },
+    {
+      "name": "data_flow",
+      "value": "debug_data_list_order",
+      "_translations": {
+        "value": {}
+      },
+      "type": "set_variable",
+      "_nested_name": "data_flow"
+    },
+    {
+      "name": "data_name",
+      "value": "debug",
+      "_translations": {
+        "value": {}
+      },
+      "type": "set_variable",
+      "_nested_name": "data_name"
+    },
+    {
+      "type": "text",
+      "value": "**Data items by flow name**",
+      "_translations": {
+        "value": {}
+      },
+      "name": "text_5",
+      "_nested_name": "text_5"
+    },
+    {
+      "type": "text",
+      "value": "Excl data",
+      "_translations": {
+        "value": {}
+      },
+      "name": "text_6",
+      "_nested_name": "text_6"
+    },
+    {
+      "type": "data_items",
+      "value": "@local.data_flow",
+      "rows": [
+        {
+          "type": "text",
+          "name": "id_@item.id",
+          "value": "Item ID: @item.id",
+          "_translations": {
+            "value": {}
+          },
+          "_nested_name": "data_items_7.id_@item.id",
+          "_dynamicFields": {
+            "name": [
+              {
+                "fullExpression": "id_@item.id",
+                "matchedExpression": "@item.id",
+                "type": "item",
+                "fieldName": "id"
+              }
+            ],
+            "value": [
+              {
+                "fullExpression": "Item ID: @item.id",
+                "matchedExpression": "@item.id",
+                "type": "item",
+                "fieldName": "id"
+              }
+            ],
+            "_nested_name": [
+              {
+                "fullExpression": "data_items_7.id_@item.id",
+                "matchedExpression": "@item.id",
+                "type": "item",
+                "fieldName": "id"
+              }
+            ]
+          },
+          "_dynamicDependencies": {
+            "@item.id": [
+              "name",
+              "value",
+              "_nested_name"
+            ]
+          }
+        }
+      ],
+      "name": "data_items_7",
+      "_nested_name": "data_items_7",
+      "_dynamicFields": {
+        "value": [
+          {
+            "fullExpression": "@local.data_flow",
+            "matchedExpression": "@local.data_flow",
+            "type": "local",
+            "fieldName": "data_flow"
+          }
+        ]
+      },
+      "_dynamicDependencies": {
+        "@local.data_flow": [
+          "value"
+        ]
+      }
+    },
+    {
+      "type": "text",
+      "value": "Incl data",
+      "_translations": {
+        "value": {}
+      },
+      "name": "text_9",
+      "_nested_name": "text_9"
+    },
+    {
+      "type": "data_items",
+      "value": "@data.@local.data_flow",
+      "condition": false,
+      "rows": [
+        {
+          "type": "text",
+          "name": "id_@item.id",
+          "value": "Item ID: @item.id",
+          "_translations": {
+            "value": {}
+          },
+          "_nested_name": "data_items_10.id_@item.id",
+          "_dynamicFields": {
+            "name": [
+              {
+                "fullExpression": "id_@item.id",
+                "matchedExpression": "@item.id",
+                "type": "item",
+                "fieldName": "id"
+              }
+            ],
+            "value": [
+              {
+                "fullExpression": "Item ID: @item.id",
+                "matchedExpression": "@item.id",
+                "type": "item",
+                "fieldName": "id"
+              }
+            ],
+            "_nested_name": [
+              {
+                "fullExpression": "data_items_10.id_@item.id",
+                "matchedExpression": "@item.id",
+                "type": "item",
+                "fieldName": "id"
+              }
+            ]
+          },
+          "_dynamicDependencies": {
+            "@item.id": [
+              "name",
+              "value",
+              "_nested_name"
+            ]
+          }
+        }
+      ],
+      "name": "data_items_10",
+      "_nested_name": "data_items_10",
+      "_dynamicFields": {
+        "value": [
+          {
+            "fullExpression": "@data.@local.data_flow",
+            "matchedExpression": "@local.data_flow",
+            "type": "local",
+            "fieldName": "data_flow"
+          }
+        ]
+      },
+      "_dynamicDependencies": {
+        "@local.data_flow": [
+          "value"
+        ]
+      }
+    },
+    {
+      "type": "text",
+      "value": "**Data items by data list name**",
+      "_translations": {
+        "value": {}
+      },
+      "name": "text_12",
+      "_nested_name": "text_12"
+    },
+    {
+      "type": "text",
+      "value": "Excl data",
+      "_translations": {
+        "value": {}
+      },
+      "name": "text_13",
+      "_nested_name": "text_13"
+    },
+    {
+      "type": "data_items",
+      "value": "@local.data_name",
+      "condition": false,
+      "rows": [
+        {
+          "type": "text",
+          "name": "id_@item.id",
+          "value": "Item ID: @item.id",
+          "_translations": {
+            "value": {}
+          },
+          "_nested_name": "data_items_14.id_@item.id",
+          "_dynamicFields": {
+            "name": [
+              {
+                "fullExpression": "id_@item.id",
+                "matchedExpression": "@item.id",
+                "type": "item",
+                "fieldName": "id"
+              }
+            ],
+            "value": [
+              {
+                "fullExpression": "Item ID: @item.id",
+                "matchedExpression": "@item.id",
+                "type": "item",
+                "fieldName": "id"
+              }
+            ],
+            "_nested_name": [
+              {
+                "fullExpression": "data_items_14.id_@item.id",
+                "matchedExpression": "@item.id",
+                "type": "item",
+                "fieldName": "id"
+              }
+            ]
+          },
+          "_dynamicDependencies": {
+            "@item.id": [
+              "name",
+              "value",
+              "_nested_name"
+            ]
+          }
+        }
+      ],
+      "name": "data_items_14",
+      "_nested_name": "data_items_14",
+      "_dynamicFields": {
+        "value": [
+          {
+            "fullExpression": "@local.data_name",
+            "matchedExpression": "@local.data_name",
+            "type": "local",
+            "fieldName": "data_name"
+          }
+        ]
+      },
+      "_dynamicDependencies": {
+        "@local.data_name": [
+          "value"
+        ]
+      }
+    },
+    {
+      "type": "text",
+      "value": "Incl data",
+      "_translations": {
+        "value": {}
+      },
+      "name": "text_16",
+      "_nested_name": "text_16"
+    },
+    {
+      "type": "data_items",
+      "value": "@data.@local.data_name",
+      "condition": false,
+      "rows": [
+        {
+          "type": "text",
+          "name": "id_@item.id",
+          "value": "Item ID: @item.id",
+          "_translations": {
+            "value": {}
+          },
+          "_nested_name": "data_items_17.id_@item.id",
+          "_dynamicFields": {
+            "name": [
+              {
+                "fullExpression": "id_@item.id",
+                "matchedExpression": "@item.id",
+                "type": "item",
+                "fieldName": "id"
+              }
+            ],
+            "value": [
+              {
+                "fullExpression": "Item ID: @item.id",
+                "matchedExpression": "@item.id",
+                "type": "item",
+                "fieldName": "id"
+              }
+            ],
+            "_nested_name": [
+              {
+                "fullExpression": "data_items_17.id_@item.id",
+                "matchedExpression": "@item.id",
+                "type": "item",
+                "fieldName": "id"
+              }
+            ]
+          },
+          "_dynamicDependencies": {
+            "@item.id": [
+              "name",
+              "value",
+              "_nested_name"
+            ]
+          }
+        }
+      ],
+      "name": "data_items_17",
+      "_nested_name": "data_items_17",
+      "_dynamicFields": {
+        "value": [
+          {
+            "fullExpression": "@data.@local.data_name",
+            "matchedExpression": "@local.data_name",
+            "type": "local",
+            "fieldName": "data_name"
+          }
+        ]
+      },
+      "_dynamicDependencies": {
+        "@local.data_name": [
+          "value"
+        ]
+      }
+    },
+    {
+      "type": "text",
+      "value": "**Items by flow name**",
+      "_translations": {
+        "value": {}
+      },
+      "name": "text_19",
+      "_nested_name": "text_19"
+    },
+    {
+      "type": "text",
+      "value": "Excl data",
+      "_translations": {
+        "value": {}
+      },
+      "name": "text_20",
+      "_nested_name": "text_20"
+    },
+    {
+      "type": "items",
+      "value": "@local.data_flow",
+      "condition": false,
+      "rows": [
+        {
+          "type": "text",
+          "name": "id_@item.id",
+          "value": "Item ID: @item.id",
+          "_translations": {
+            "value": {}
+          },
+          "_nested_name": "items_21.id_@item.id",
+          "_dynamicFields": {
+            "name": [
+              {
+                "fullExpression": "id_@item.id",
+                "matchedExpression": "@item.id",
+                "type": "item",
+                "fieldName": "id"
+              }
+            ],
+            "value": [
+              {
+                "fullExpression": "Item ID: @item.id",
+                "matchedExpression": "@item.id",
+                "type": "item",
+                "fieldName": "id"
+              }
+            ],
+            "_nested_name": [
+              {
+                "fullExpression": "items_21.id_@item.id",
+                "matchedExpression": "@item.id",
+                "type": "item",
+                "fieldName": "id"
+              }
+            ]
+          },
+          "_dynamicDependencies": {
+            "@item.id": [
+              "name",
+              "value",
+              "_nested_name"
+            ]
+          }
+        }
+      ],
+      "name": "items_21",
+      "_nested_name": "items_21",
+      "_dynamicFields": {
+        "value": [
+          {
+            "fullExpression": "@local.data_flow",
+            "matchedExpression": "@local.data_flow",
+            "type": "local",
+            "fieldName": "data_flow"
+          }
+        ]
+      },
+      "_dynamicDependencies": {
+        "@local.data_flow": [
+          "value"
+        ]
+      }
+    },
+    {
+      "type": "text",
+      "value": "Incl data",
+      "_translations": {
+        "value": {}
+      },
+      "name": "text_23",
+      "_nested_name": "text_23"
+    },
+    {
+      "type": "items",
+      "value": "@data.@local.data_flow",
+      "rows": [
+        {
+          "type": "text",
+          "name": "id_@item.id",
+          "value": "Item ID: @item.id",
+          "_translations": {
+            "value": {}
+          },
+          "_nested_name": "items_24.id_@item.id",
+          "_dynamicFields": {
+            "name": [
+              {
+                "fullExpression": "id_@item.id",
+                "matchedExpression": "@item.id",
+                "type": "item",
+                "fieldName": "id"
+              }
+            ],
+            "value": [
+              {
+                "fullExpression": "Item ID: @item.id",
+                "matchedExpression": "@item.id",
+                "type": "item",
+                "fieldName": "id"
+              }
+            ],
+            "_nested_name": [
+              {
+                "fullExpression": "items_24.id_@item.id",
+                "matchedExpression": "@item.id",
+                "type": "item",
+                "fieldName": "id"
+              }
+            ]
+          },
+          "_dynamicDependencies": {
+            "@item.id": [
+              "name",
+              "value",
+              "_nested_name"
+            ]
+          }
+        }
+      ],
+      "name": "items_24",
+      "_nested_name": "items_24",
+      "_dynamicFields": {
+        "value": [
+          {
+            "fullExpression": "@data.@local.data_flow",
+            "matchedExpression": "@local.data_flow",
+            "type": "local",
+            "fieldName": "data_flow"
+          }
+        ]
+      },
+      "_dynamicDependencies": {
+        "@local.data_flow": [
+          "value"
+        ]
+      }
+    },
+    {
+      "type": "text",
+      "value": "**Items by data list name**",
+      "_translations": {
+        "value": {}
+      },
+      "name": "text_26",
+      "_nested_name": "text_26"
+    },
+    {
+      "type": "text",
+      "value": "Excl data",
+      "_translations": {
+        "value": {}
+      },
+      "name": "text_27",
+      "_nested_name": "text_27"
+    },
+    {
+      "type": "items",
+      "value": "@local.data_name",
+      "condition": false,
+      "rows": [
+        {
+          "type": "text",
+          "name": "id_@item.id",
+          "value": "Item ID: @item.id",
+          "_translations": {
+            "value": {}
+          },
+          "_nested_name": "items_28.id_@item.id",
+          "_dynamicFields": {
+            "name": [
+              {
+                "fullExpression": "id_@item.id",
+                "matchedExpression": "@item.id",
+                "type": "item",
+                "fieldName": "id"
+              }
+            ],
+            "value": [
+              {
+                "fullExpression": "Item ID: @item.id",
+                "matchedExpression": "@item.id",
+                "type": "item",
+                "fieldName": "id"
+              }
+            ],
+            "_nested_name": [
+              {
+                "fullExpression": "items_28.id_@item.id",
+                "matchedExpression": "@item.id",
+                "type": "item",
+                "fieldName": "id"
+              }
+            ]
+          },
+          "_dynamicDependencies": {
+            "@item.id": [
+              "name",
+              "value",
+              "_nested_name"
+            ]
+          }
+        }
+      ],
+      "name": "items_28",
+      "_nested_name": "items_28",
+      "_dynamicFields": {
+        "value": [
+          {
+            "fullExpression": "@local.data_name",
+            "matchedExpression": "@local.data_name",
+            "type": "local",
+            "fieldName": "data_name"
+          }
+        ]
+      },
+      "_dynamicDependencies": {
+        "@local.data_name": [
+          "value"
+        ]
+      }
+    },
+    {
+      "type": "text",
+      "value": "Incl data",
+      "_translations": {
+        "value": {}
+      },
+      "name": "text_30",
+      "_nested_name": "text_30"
+    },
+    {
+      "type": "items",
+      "value": "@data.@local.data_name",
+      "condition": false,
+      "rows": [
+        {
+          "type": "text",
+          "name": "id_@item.id",
+          "value": "Item ID: @item.id",
+          "_translations": {
+            "value": {}
+          },
+          "_nested_name": "items_31.id_@item.id",
+          "_dynamicFields": {
+            "name": [
+              {
+                "fullExpression": "id_@item.id",
+                "matchedExpression": "@item.id",
+                "type": "item",
+                "fieldName": "id"
+              }
+            ],
+            "value": [
+              {
+                "fullExpression": "Item ID: @item.id",
+                "matchedExpression": "@item.id",
+                "type": "item",
+                "fieldName": "id"
+              }
+            ],
+            "_nested_name": [
+              {
+                "fullExpression": "items_31.id_@item.id",
+                "matchedExpression": "@item.id",
+                "type": "item",
+                "fieldName": "id"
+              }
+            ]
+          },
+          "_dynamicDependencies": {
+            "@item.id": [
+              "name",
+              "value",
+              "_nested_name"
+            ]
+          }
+        }
+      ],
+      "name": "items_31",
+      "_nested_name": "items_31",
+      "_dynamicFields": {
+        "value": [
+          {
+            "fullExpression": "@data.@local.data_name",
+            "matchedExpression": "@local.data_name",
+            "type": "local",
+            "fieldName": "data_name"
+          }
+        ]
+      },
+      "_dynamicDependencies": {
+        "@local.data_name": [
+          "value"
+        ]
+      }
+    }
+  ],
+  "_xlsxPath": "debug_sheets/debug_data_items.xlsx"
+}

--- a/app_data/sheets/template/debug/debug_fullscreen_pop_up_1.json
+++ b/app_data/sheets/template/debug/debug_fullscreen_pop_up_1.json
@@ -6,7 +6,31 @@
   "rows": [
     {
       "type": "button",
-      "value": "Launch fullscreen popup",
+      "value": "Launch fullscreen popup (new style)",
+      "_translations": {
+        "value": {}
+      },
+      "action_list": [
+        {
+          "trigger": "click",
+          "action_id": "pop_up",
+          "args": [
+            "debug_fullscreen_pop_up_2"
+          ],
+          "_raw": "click | pop_up: debug_fullscreen_pop_up_2 | fullscreen_alt: true",
+          "_cleaned": "click | pop_up: debug_fullscreen_pop_up_2 | fullscreen_alt: true",
+          "params": {
+            "fullscreen_alt": true
+          }
+        }
+      ],
+      "exclude_from_translation": true,
+      "name": "button_2",
+      "_nested_name": "button_2"
+    },
+    {
+      "type": "button",
+      "value": "Launch fullscreen popup (old style)",
       "_translations": {
         "value": {}
       },
@@ -25,8 +49,8 @@
         }
       ],
       "exclude_from_translation": true,
-      "name": "button_2",
-      "_nested_name": "button_2"
+      "name": "button_3",
+      "_nested_name": "button_3"
     }
   ],
   "_xlsxPath": "debug_sheets/to_be_sorted/debug_fullscreen_pop_up.xlsx"

--- a/app_data/sheets/template/debug/debug_kids.json
+++ b/app_data/sheets/template/debug/debug_kids.json
@@ -1,0 +1,624 @@
+{
+  "flow_type": "template",
+  "flow_name": "debug_kids",
+  "status": "released",
+  "flow_subtype": "debug",
+  "rows": [
+    {
+      "type": "title",
+      "name": "title",
+      "value": "Find first item in data list with a certain property",
+      "_translations": {
+        "value": {}
+      },
+      "_nested_name": "title"
+    },
+    {
+      "name": "type",
+      "value": "type_b",
+      "_translations": {
+        "value": {}
+      },
+      "type": "set_variable",
+      "_nested_name": "type"
+    },
+    {
+      "type": "text",
+      "name": "text_templating",
+      "value": "Data items approach",
+      "_translations": {
+        "value": {}
+      },
+      "parameter_list": {
+        "style": "emphasised"
+      },
+      "_nested_name": "text_templating"
+    },
+    {
+      "type": "data_items",
+      "name": "find_first_item_of_this_type",
+      "value": "@data.comp_data_items_list",
+      "rows": [
+        {
+          "type": "display_group",
+          "name": "stop_when_found_first_match_@item.id",
+          "condition": "@item.type == @local.type",
+          "rows": [
+            {
+              "type": "text",
+              "name": "debug_loc_type_@item.id",
+              "value": "Local: @local.type",
+              "_translations": {
+                "value": {}
+              },
+              "_nested_name": "find_first_item_of_this_type.stop_when_found_first_match_@item.id.debug_loc_type_@item.id",
+              "_dynamicFields": {
+                "name": [
+                  {
+                    "fullExpression": "debug_loc_type_@item.id",
+                    "matchedExpression": "@item.id",
+                    "type": "item",
+                    "fieldName": "id"
+                  }
+                ],
+                "value": [
+                  {
+                    "fullExpression": "Local: @local.type",
+                    "matchedExpression": "@local.type",
+                    "type": "local",
+                    "fieldName": "type"
+                  }
+                ],
+                "_nested_name": [
+                  {
+                    "fullExpression": "find_first_item_of_this_type.stop_when_found_first_match_@item.id.debug_loc_type_@item.id",
+                    "matchedExpression": "@item.id.debug_loc_type_",
+                    "type": "item",
+                    "fieldName": "id"
+                  },
+                  {
+                    "fullExpression": "find_first_item_of_this_type.stop_when_found_first_match_@item.id.debug_loc_type_@item.id",
+                    "matchedExpression": "@item.id",
+                    "type": "item",
+                    "fieldName": "id"
+                  }
+                ]
+              },
+              "_dynamicDependencies": {
+                "@item.id": [
+                  "name",
+                  "_nested_name"
+                ],
+                "@local.type": [
+                  "value"
+                ],
+                "@item.id.debug_loc_type_": [
+                  "_nested_name"
+                ]
+              }
+            },
+            {
+              "type": "text",
+              "name": "debug_item_type_@item.id",
+              "value": "Item: @item.type",
+              "_translations": {
+                "value": {}
+              },
+              "_nested_name": "find_first_item_of_this_type.stop_when_found_first_match_@item.id.debug_item_type_@item.id",
+              "_dynamicFields": {
+                "name": [
+                  {
+                    "fullExpression": "debug_item_type_@item.id",
+                    "matchedExpression": "@item.id",
+                    "type": "item",
+                    "fieldName": "id"
+                  }
+                ],
+                "value": [
+                  {
+                    "fullExpression": "Item: @item.type",
+                    "matchedExpression": "@item.type",
+                    "type": "item",
+                    "fieldName": "type"
+                  }
+                ],
+                "_nested_name": [
+                  {
+                    "fullExpression": "find_first_item_of_this_type.stop_when_found_first_match_@item.id.debug_item_type_@item.id",
+                    "matchedExpression": "@item.id.debug_item_type_",
+                    "type": "item",
+                    "fieldName": "id"
+                  },
+                  {
+                    "fullExpression": "find_first_item_of_this_type.stop_when_found_first_match_@item.id.debug_item_type_@item.id",
+                    "matchedExpression": "@item.id",
+                    "type": "item",
+                    "fieldName": "id"
+                  }
+                ]
+              },
+              "_dynamicDependencies": {
+                "@item.id": [
+                  "name",
+                  "_nested_name"
+                ],
+                "@item.type": [
+                  "value"
+                ],
+                "@item.id.debug_item_type_": [
+                  "_nested_name"
+                ]
+              }
+            },
+            {
+              "type": "text",
+              "name": "debug_failed",
+              "value": "Condition failed",
+              "_translations": {
+                "value": {}
+              },
+              "condition": "@item.type !== @local.type",
+              "_nested_name": "find_first_item_of_this_type.stop_when_found_first_match_@item.id.debug_failed",
+              "_dynamicFields": {
+                "condition": [
+                  {
+                    "fullExpression": "@item.type !== @local.type",
+                    "matchedExpression": "@item.type",
+                    "type": "item",
+                    "fieldName": "type"
+                  },
+                  {
+                    "fullExpression": "@item.type !== @local.type",
+                    "matchedExpression": "@local.type",
+                    "type": "local",
+                    "fieldName": "type"
+                  }
+                ],
+                "_nested_name": [
+                  {
+                    "fullExpression": "find_first_item_of_this_type.stop_when_found_first_match_@item.id.debug_failed",
+                    "matchedExpression": "@item.id.debug_failed",
+                    "type": "item",
+                    "fieldName": "id"
+                  }
+                ]
+              },
+              "_dynamicDependencies": {
+                "@item.type": [
+                  "condition"
+                ],
+                "@local.type": [
+                  "condition"
+                ],
+                "@item.id.debug_failed": [
+                  "_nested_name"
+                ]
+              }
+            },
+            {
+              "type": "text",
+              "name": "debug_passed",
+              "value": "Condition passed",
+              "_translations": {
+                "value": {}
+              },
+              "condition": "@item.type == @local.type",
+              "_nested_name": "find_first_item_of_this_type.stop_when_found_first_match_@item.id.debug_passed",
+              "_dynamicFields": {
+                "condition": [
+                  {
+                    "fullExpression": "@item.type == @local.type",
+                    "matchedExpression": "@item.type",
+                    "type": "item",
+                    "fieldName": "type"
+                  },
+                  {
+                    "fullExpression": "@item.type == @local.type",
+                    "matchedExpression": "@local.type",
+                    "type": "local",
+                    "fieldName": "type"
+                  }
+                ],
+                "_nested_name": [
+                  {
+                    "fullExpression": "find_first_item_of_this_type.stop_when_found_first_match_@item.id.debug_passed",
+                    "matchedExpression": "@item.id.debug_passed",
+                    "type": "item",
+                    "fieldName": "id"
+                  }
+                ]
+              },
+              "_dynamicDependencies": {
+                "@item.type": [
+                  "condition"
+                ],
+                "@local.type": [
+                  "condition"
+                ],
+                "@item.id.debug_passed": [
+                  "_nested_name"
+                ]
+              }
+            },
+            {
+              "name": "id",
+              "value": "@item.id",
+              "_translations": {
+                "value": {}
+              },
+              "type": "set_variable",
+              "_nested_name": "find_first_item_of_this_type.stop_when_found_first_match_@item.id.id",
+              "_dynamicFields": {
+                "value": [
+                  {
+                    "fullExpression": "@item.id",
+                    "matchedExpression": "@item.id",
+                    "type": "item",
+                    "fieldName": "id"
+                  }
+                ],
+                "_nested_name": [
+                  {
+                    "fullExpression": "find_first_item_of_this_type.stop_when_found_first_match_@item.id.id",
+                    "matchedExpression": "@item.id.id",
+                    "type": "item",
+                    "fieldName": "id"
+                  }
+                ]
+              },
+              "_dynamicDependencies": {
+                "@item.id": [
+                  "value"
+                ],
+                "@item.id.id": [
+                  "_nested_name"
+                ]
+              }
+            },
+            {
+              "name": "stop_loop",
+              "value": true,
+              "type": "set_variable",
+              "_nested_name": "find_first_item_of_this_type.stop_when_found_first_match_@item.id.stop_loop",
+              "_dynamicFields": {
+                "_nested_name": [
+                  {
+                    "fullExpression": "find_first_item_of_this_type.stop_when_found_first_match_@item.id.stop_loop",
+                    "matchedExpression": "@item.id.stop_loop",
+                    "type": "item",
+                    "fieldName": "id"
+                  }
+                ]
+              },
+              "_dynamicDependencies": {
+                "@item.id.stop_loop": [
+                  "_nested_name"
+                ]
+              }
+            }
+          ],
+          "_nested_name": "find_first_item_of_this_type.stop_when_found_first_match_@item.id",
+          "_dynamicFields": {
+            "name": [
+              {
+                "fullExpression": "stop_when_found_first_match_@item.id",
+                "matchedExpression": "@item.id",
+                "type": "item",
+                "fieldName": "id"
+              }
+            ],
+            "condition": [
+              {
+                "fullExpression": "@item.type == @local.type",
+                "matchedExpression": "@item.type",
+                "type": "item",
+                "fieldName": "type"
+              },
+              {
+                "fullExpression": "@item.type == @local.type",
+                "matchedExpression": "@local.type",
+                "type": "local",
+                "fieldName": "type"
+              }
+            ],
+            "_nested_name": [
+              {
+                "fullExpression": "find_first_item_of_this_type.stop_when_found_first_match_@item.id",
+                "matchedExpression": "@item.id",
+                "type": "item",
+                "fieldName": "id"
+              }
+            ]
+          },
+          "_dynamicDependencies": {
+            "@item.id": [
+              "name",
+              "_nested_name"
+            ],
+            "@item.type": [
+              "condition"
+            ],
+            "@local.type": [
+              "condition"
+            ]
+          }
+        }
+      ],
+      "_nested_name": "find_first_item_of_this_type",
+      "_dynamicFields": {
+        "value": [
+          {
+            "fullExpression": "@data.comp_data_items_list",
+            "matchedExpression": "@data.comp_data_items_list",
+            "type": "data",
+            "fieldName": "comp_data_items_list"
+          }
+        ]
+      },
+      "_dynamicDependencies": {
+        "@data.comp_data_items_list": [
+          "value"
+        ]
+      }
+    },
+    {
+      "type": "text",
+      "name": "text_result",
+      "value": "The first item of type @local.type is @local.id",
+      "_translations": {
+        "value": {}
+      },
+      "_nested_name": "text_result",
+      "_dynamicFields": {
+        "value": [
+          {
+            "fullExpression": "The first item of type @local.type is @local.id",
+            "matchedExpression": "@local.type",
+            "type": "local",
+            "fieldName": "type"
+          },
+          {
+            "fullExpression": "The first item of type @local.type is @local.id",
+            "matchedExpression": "@local.id",
+            "type": "local",
+            "fieldName": "id"
+          }
+        ]
+      },
+      "_dynamicDependencies": {
+        "@local.type": [
+          "value"
+        ],
+        "@local.id": [
+          "value"
+        ]
+      }
+    },
+    {
+      "type": "text",
+      "name": "text_js",
+      "value": "Javascript workaround",
+      "_translations": {
+        "value": {}
+      },
+      "parameter_list": {
+        "style": "emphasised"
+      },
+      "_nested_name": "text_js"
+    },
+    {
+      "name": "data_json",
+      "value": "@data.comp_data_items_list",
+      "_translations": {
+        "value": {}
+      },
+      "type": "set_variable",
+      "_nested_name": "data_json",
+      "_dynamicFields": {
+        "value": [
+          {
+            "fullExpression": "@data.comp_data_items_list",
+            "matchedExpression": "@data.comp_data_items_list",
+            "type": "data",
+            "fieldName": "comp_data_items_list"
+          }
+        ]
+      },
+      "_dynamicDependencies": {
+        "@data.comp_data_items_list": [
+          "value"
+        ]
+      }
+    },
+    {
+      "name": "stringify_data",
+      "value": "@calc(JSON.stringify(@local.data_json))",
+      "_translations": {
+        "value": {}
+      },
+      "type": "set_variable",
+      "_nested_name": "stringify_data",
+      "_dynamicFields": {
+        "value": [
+          {
+            "fullExpression": "@calc(JSON.stringify(@local.data_json))",
+            "matchedExpression": "@local.data_json",
+            "type": "local",
+            "fieldName": "data_json"
+          },
+          {
+            "fullExpression": "@calc(JSON.stringify(@local.data_json))",
+            "matchedExpression": "@calc(JSON.stringify(@local.data_json))",
+            "type": "calc",
+            "fieldName": "JSON.stringify(@local.data_json)"
+          }
+        ]
+      },
+      "_dynamicDependencies": {
+        "@local.data_json": [
+          "value"
+        ],
+        "@calc(JSON.stringify(@local.data_json))": [
+          "value"
+        ]
+      }
+    },
+    {
+      "type": "text",
+      "name": "debug_data",
+      "value": "Data: @local.stringify_data",
+      "_translations": {
+        "value": {}
+      },
+      "_nested_name": "debug_data",
+      "_dynamicFields": {
+        "value": [
+          {
+            "fullExpression": "Data: @local.stringify_data",
+            "matchedExpression": "@local.stringify_data",
+            "type": "local",
+            "fieldName": "stringify_data"
+          }
+        ]
+      },
+      "_dynamicDependencies": {
+        "@local.stringify_data": [
+          "value"
+        ]
+      }
+    },
+    {
+      "name": "data_array",
+      "value": "@calc(Object.values(@local.data_json))",
+      "_translations": {
+        "value": {}
+      },
+      "type": "set_variable",
+      "_nested_name": "data_array",
+      "_dynamicFields": {
+        "value": [
+          {
+            "fullExpression": "@calc(Object.values(@local.data_json))",
+            "matchedExpression": "@local.data_json",
+            "type": "local",
+            "fieldName": "data_json"
+          },
+          {
+            "fullExpression": "@calc(Object.values(@local.data_json))",
+            "matchedExpression": "@calc(Object.values(@local.data_json))",
+            "type": "calc",
+            "fieldName": "Object.values(@local.data_json)"
+          }
+        ]
+      },
+      "_dynamicDependencies": {
+        "@local.data_json": [
+          "value"
+        ],
+        "@calc(Object.values(@local.data_json))": [
+          "value"
+        ]
+      }
+    },
+    {
+      "name": "match_json",
+      "value": "@calc(@local.data_array.find((row) => row.type === @local.type))",
+      "_translations": {
+        "value": {}
+      },
+      "type": "set_variable",
+      "_nested_name": "match_json",
+      "_dynamicFields": {
+        "value": [
+          {
+            "fullExpression": "@calc(@local.data_array.find((row) => row.type === @local.type))",
+            "matchedExpression": "@local.data_array.find",
+            "type": "local",
+            "fieldName": "data_array"
+          },
+          {
+            "fullExpression": "@calc(@local.data_array.find((row) => row.type === @local.type))",
+            "matchedExpression": "@local.type",
+            "type": "local",
+            "fieldName": "type"
+          },
+          {
+            "fullExpression": "@calc(@local.data_array.find((row) => row.type === @local.type))",
+            "matchedExpression": "@calc(@local.data_array.find((row) => row.type === @local.type))",
+            "type": "calc",
+            "fieldName": "@local.data_array.find((row) => row.type === @local.type)"
+          }
+        ]
+      },
+      "_dynamicDependencies": {
+        "@local.data_array.find": [
+          "value"
+        ],
+        "@local.type": [
+          "value"
+        ],
+        "@calc(@local.data_array.find((row) => row.type === @local.type))": [
+          "value"
+        ]
+      }
+    },
+    {
+      "name": "id_js",
+      "value": "@local.match_json.id",
+      "_translations": {
+        "value": {}
+      },
+      "type": "set_variable",
+      "_nested_name": "id_js",
+      "_dynamicFields": {
+        "value": [
+          {
+            "fullExpression": "@local.match_json.id",
+            "matchedExpression": "@local.match_json.id",
+            "type": "local",
+            "fieldName": "match_json"
+          }
+        ]
+      },
+      "_dynamicDependencies": {
+        "@local.match_json.id": [
+          "value"
+        ]
+      }
+    },
+    {
+      "type": "text",
+      "name": "text_result_js",
+      "value": "The first item of type @local.type is @local.id_js",
+      "_translations": {
+        "value": {}
+      },
+      "_nested_name": "text_result_js",
+      "_dynamicFields": {
+        "value": [
+          {
+            "fullExpression": "The first item of type @local.type is @local.id_js",
+            "matchedExpression": "@local.type",
+            "type": "local",
+            "fieldName": "type"
+          },
+          {
+            "fullExpression": "The first item of type @local.type is @local.id_js",
+            "matchedExpression": "@local.id_js",
+            "type": "local",
+            "fieldName": "id_js"
+          }
+        ]
+      },
+      "_dynamicDependencies": {
+        "@local.type": [
+          "value"
+        ],
+        "@local.id_js": [
+          "value"
+        ]
+      }
+    }
+  ],
+  "_xlsxPath": "debug_sheets/debug_data_items.xlsx"
+}

--- a/app_data/sheets/template/feature_rtl_language.json
+++ b/app_data/sheets/template/feature_rtl_language.json
@@ -1,0 +1,128 @@
+{
+  "flow_type": "template",
+  "flow_name": "feature_rtl_language",
+  "status": "released",
+  "rows": [
+    {
+      "type": "title",
+      "value": "RTL language support",
+      "_translations": {
+        "value": {}
+      },
+      "name": "title_2",
+      "_nested_name": "title_2"
+    },
+    {
+      "type": "text",
+      "value": "Some text",
+      "_translations": {
+        "value": {}
+      },
+      "name": "text_3",
+      "_nested_name": "text_3"
+    },
+    {
+      "name": "language_list",
+      "value": [
+        {
+          "name": "gb_en",
+          "text": "English"
+        },
+        {
+          "name": "en_rtl",
+          "text": "English RTL"
+        }
+      ],
+      "exclude_from_translation": true,
+      "type": "set_variable",
+      "_nested_name": "language_list"
+    },
+    {
+      "type": "radio_group",
+      "name": "language_select",
+      "value": "@fields._app_language",
+      "_translations": {
+        "value": {}
+      },
+      "action_list": [
+        {
+          "trigger": "changed",
+          "action_id": "emit",
+          "args": [
+            "set_language",
+            "this.value"
+          ],
+          "_raw": "changed | emit: set_language:@local.language_select",
+          "_cleaned": "changed | emit: set_language:@local.language_select"
+        },
+        {
+          "trigger": "changed",
+          "action_id": "emit",
+          "args": [
+            "force_reload"
+          ],
+          "_raw": "changed | emit: force_reload",
+          "_cleaned": "changed | emit: force_reload"
+        }
+      ],
+      "parameter_list": {
+        "answer_list": "@local.language_list"
+      },
+      "exclude_from_translation": true,
+      "_nested_name": "language_select",
+      "_dynamicFields": {
+        "value": [
+          {
+            "fullExpression": "@fields._app_language",
+            "matchedExpression": "@fields._app_language",
+            "type": "fields",
+            "fieldName": "_app_language"
+          }
+        ],
+        "action_list": {
+          "0": {
+            "_raw": [
+              {
+                "fullExpression": "changed | emit: set_language:@local.language_select",
+                "matchedExpression": "@local.language_select",
+                "type": "local",
+                "fieldName": "language_select"
+              }
+            ],
+            "_cleaned": [
+              {
+                "fullExpression": "changed | emit: set_language:@local.language_select",
+                "matchedExpression": "@local.language_select",
+                "type": "local",
+                "fieldName": "language_select"
+              }
+            ]
+          }
+        },
+        "parameter_list": {
+          "answer_list": [
+            {
+              "fullExpression": "@local.language_list",
+              "matchedExpression": "@local.language_list",
+              "type": "local",
+              "fieldName": "language_list"
+            }
+          ]
+        }
+      },
+      "_dynamicDependencies": {
+        "@fields._app_language": [
+          "value"
+        ],
+        "@local.language_select": [
+          "action_list.0._raw",
+          "action_list.0._cleaned"
+        ],
+        "@local.language_list": [
+          "parameter_list.answer_list"
+        ]
+      }
+    }
+  ],
+  "_xlsxPath": "feature_sheets/feature_rtl_language.xlsx"
+}

--- a/app_data/sheets/template/feature_rtl_language.json
+++ b/app_data/sheets/template/feature_rtl_language.json
@@ -14,9 +14,11 @@
     },
     {
       "type": "text",
-      "value": "Some text",
+      "value": "Some text in English",
       "_translations": {
-        "value": {}
+        "value": {
+          "en_rtl": true
+        }
       },
       "name": "text_3",
       "_nested_name": "text_3"
@@ -26,11 +28,11 @@
       "value": [
         {
           "name": "gb_en",
-          "text": "English"
+          "text": "1. English"
         },
         {
           "name": "en_rtl",
-          "text": "English RTL"
+          "text": "2. English RTL"
         }
       ],
       "exclude_from_translation": true,
@@ -52,8 +54,8 @@
             "set_language",
             "this.value"
           ],
-          "_raw": "changed | emit: set_language:@local.language_select",
-          "_cleaned": "changed | emit: set_language:@local.language_select"
+          "_raw": "changed | emit: set_language: @local.language_select",
+          "_cleaned": "changed | emit: set_language: @local.language_select"
         },
         {
           "trigger": "changed",
@@ -83,7 +85,7 @@
           "0": {
             "_raw": [
               {
-                "fullExpression": "changed | emit: set_language:@local.language_select",
+                "fullExpression": "changed | emit: set_language: @local.language_select",
                 "matchedExpression": "@local.language_select",
                 "type": "local",
                 "fieldName": "language_select"
@@ -91,7 +93,7 @@
             ],
             "_cleaned": [
               {
-                "fullExpression": "changed | emit: set_language:@local.language_select",
+                "fullExpression": "changed | emit: set_language: @local.language_select",
                 "matchedExpression": "@local.language_select",
                 "type": "local",
                 "fieldName": "language_select"

--- a/app_data/translations/contents.json
+++ b/app_data/translations/contents.json
@@ -1,4 +1,7 @@
 {
+  "en_rtl": {
+    "filename": "en_rtl/strings.json"
+  },
   "es_sp": {
     "filename": "es_sp/strings.json"
   }

--- a/app_data/translations/en_rtl/strings.json
+++ b/app_data/translations/en_rtl/strings.json
@@ -1,0 +1,3 @@
+{
+  "Some text in English": "hsilgnE LTR ni txet emoS"
+}

--- a/app_data/translations_source/translated_strings/translated.en_rtl.json
+++ b/app_data/translations_source/translated_strings/translated.en_rtl.json
@@ -1,0 +1,7 @@
+[
+  {
+    "SourceText": "Some text in English",
+    "text": "hsilgnE LTR ni txet emoS",
+    "type": "template"
+  }
+]

--- a/config.ts
+++ b/config.ts
@@ -1,4 +1,4 @@
-import { generateDeploymentConfig, loadEncryptedConfig} from "scripts";
+import { generateDeploymentConfig, loadEncryptedConfig } from "scripts";
 import { SKINS } from "./skins";
 
 const config = generateDeploymentConfig("debug");
@@ -14,7 +14,7 @@ config.web.favicon_asset = "images/icons/favicon.svg";
 
 config.git = {
   content_repo: "https://github.com/IDEMSInternational/app-debug-content.git",
-  content_tag_latest: "1.2.28",
+  content_tag_latest: "1.2.29",
 };
 
 config.app_config.ASSET_PACKS = {
@@ -27,12 +27,12 @@ config.app_config.ASSET_PACKS = {
 // TODO - should supabase match general config and additional settings
 
 const supabaseConfig = loadEncryptedConfig("supabaseConfig.json");
-config.supabase = { ...supabaseConfig, enabled: supabaseConfig ? true : false  };
+config.supabase = { ...supabaseConfig, enabled: supabaseConfig ? true : false };
 
 config.firebase = {
   config: loadEncryptedConfig('firebase.json'),
-  auth:{enabled:true},
-  crashlytics:{enabled:true}
+  auth: { enabled: true },
+  crashlytics: { enabled: true }
 }
 
 config.error_logging = {
@@ -75,5 +75,7 @@ config.app_config.APP_UPDATES.completeUpdateTemplate = "app_update_complete"
 
 config.app_config.APP_AUTHENTICATION_DEFAULTS.enforceLogin = false
 config.app_config.APP_AUTHENTICATION_DEFAULTS.signInTemplate = "example_google_auth"
+
+config.app_config.APP_LANGUAGES_META = { en_rtl: { rtl: true } }
 
 export default config;


### PR DESCRIPTION
Includes updates to the deployment config to support RTL languages, along with some manually added translations to test this feature via the [feature_rtl_language](https://docs.google.com/spreadsheets/d/1DkWnJrpR6pjHpPiNNfGXR4sJpCXiaRnElebeorh8sLY/edit#gid=569531329) template. Should be merged after https://github.com/IDEMSInternational/parenting-app-ui/pull/2317.