### PR TITLE
chore: update references 'parenting-app-ui' -> 'open-app-builder'

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -8,5 +8,5 @@ on:
 
 jobs:
   android_release:
-    uses: IDEMSInternational/parenting-app-ui/.github/workflows/reusable-android-release.yml@master
+    uses: IDEMSInternational/open-app-builder/.github/workflows/reusable-android-release.yml@master
     secrets: inherit

--- a/.github/workflows/content-sync.yml
+++ b/.github/workflows/content-sync.yml
@@ -16,7 +16,7 @@ on:
           default: Automated PR creation from actions
 jobs:
   sync_content:
-    uses: IDEMSInternational/parenting-app-ui/.github/workflows/reusable-content-sync.yml@master
+    uses: IDEMSInternational/open-app-builder/.github/workflows/reusable-content-sync.yml@master
     with:
       pr-title: ${{ inputs.pr-title }}
       pr-body: ${{ inputs.pr-body }}

--- a/.github/workflows/deploy-firebase.yml
+++ b/.github/workflows/deploy-firebase.yml
@@ -10,6 +10,6 @@ on:
 
 jobs:
   web_preview:
-    uses: IDEMSInternational/parenting-app-ui/.github/workflows/reusable-deploy-web-preview.yml@master
+    uses: IDEMSInternational/open-app-builder/.github/workflows/reusable-deploy-web-preview.yml@master
     secrets: inherit
 

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -9,5 +9,5 @@ on:
 
 jobs:
   pr_preview:
-    uses: IDEMSInternational/parenting-app-ui/.github/workflows/reusable-deploy-pr-preview.yml@master
+    uses: IDEMSInternational/open-app-builder/.github/workflows/reusable-deploy-pr-preview.yml@master
     secrets: inherit

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This content is designed to be integrated with the IDEMS App ecosystem, available at:
 
-https://github.com/IDEMSInternational/parenting-app-ui
+https://github.com/IDEMSInternational/open-app-builder
 
 The content can be imported into the parent app via the script
 
@@ -11,5 +11,5 @@ yarn workflow deployment import https://github.com/IDEMSInternational/app-debug-
 ```
 
 For more information on app repo integration see documentation at:
-https://idemsinternational.github.io/parenting-app-ui/developers/deployments/#github-management
+https://idemsinternational.github.io/open-app-builder/developers/deployments/#github-management
 


### PR DESCRIPTION
Updates all references to the code repo from "parenting-app-ui" to "open-app-builder" to reflect the change of name of the repo. This includes references in the action yaml files and the README file.