### PR TITLE
feat: add analytics config

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -48,6 +48,13 @@ config.android = {
   icon_asset_background_path: "./app_data/assets/android/icon-background.png",
 }
 
+config.analytics={
+  enabled:true,
+  provider:'matomo',
+  siteId: 2,
+  endpoint: "https://apps-server.idems.international/analytics"
+}
+
 config.ios.app_id = "international.idems.debug-app"
 config.ios.app_name = "Debug App"
 


### PR DESCRIPTION
Following https://github.com/IDEMSInternational/open-app-builder/pull/2412, add specific config for debug analytics

This should enable all analytics for the debug site to be captured at a newly created matomo site

**Example - Matomo dashboard with created siteId**
![image](https://github.com/user-attachments/assets/f8528342-e85c-420b-ae41-36c51e769ce5)

**Example - Realtime map showing debug site access**
![image](https://github.com/user-attachments/assets/1c7001a6-5622-4fd5-959b-0d54f4c5273a)



