### PR TITLE
chore: update debug skin

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -53,7 +53,6 @@ config.ios.app_name = "Debug App"
 
 // Override any app constants here
 config.app_config.APP_HEADER_DEFAULTS.title = "Debug App";
-config.app_config.APP_HEADER_DEFAULTS.collapse = true;
 config.app_config.APP_HEADER_DEFAULTS.colour = "primary";
 config.app_config.APP_HEADER_DEFAULTS.variant = "default";
 

--- a/skins/debug.ts
+++ b/skins/debug.ts
@@ -8,11 +8,21 @@ const debug: IAppSkin = {
     },
     APP_HEADER_DEFAULTS:
     {
-      title: "Debug Skin"
+      title: "Debug Skin",
+      collapse:true,
+      colour:'secondary',
+      variant:'compact'
+    },
+    APP_FOOTER_DEFAULTS:{
+      templateName:''
     },
     APP_ROUTE_DEFAULTS: {
       home_route: "/template/test"
+    },
+    APP_THEMES:{
+      defaultThemeName:'professional'
     }
+    
   },
 };
 export default debug;


### PR DESCRIPTION
Update debug skin to be more visually different than default and allow testing of app header and footer changes

**Default Skin** - most unchanged except now header collapse is set to `false` (in main config)
![localhost_4200_template_debug_skin_select](https://github.com/user-attachments/assets/f896121f-cd49-4b7b-aed8-97b1d1dde6d7)

**Debug Skin** - includes collapsed header, professional theme, secondary header and no footer
![localhost_4200_template_debug_skin_select (1)](https://github.com/user-attachments/assets/08f274df-c115-4950-acf1-be7195882e1f)
