### PR TITLE
content: 1.4.6

### DIFF
--- a/app_data/sheets/contents.json
+++ b/app_data/sheets/contents.json
@@ -1413,6 +1413,12 @@
       "flow_subtype": "component_demo",
       "_xlsxPath": "component_sheets/component_display_grid.xlsx"
     },
+    "comp_display_group": {
+      "flow_type": "template",
+      "flow_name": "comp_display_group",
+      "flow_subtype": "component_demo",
+      "_xlsxPath": "component_sheets/component_display_group.xlsx"
+    },
     "comp_drawer": {
       "flow_type": "template",
       "flow_name": "comp_drawer",
@@ -3699,11 +3705,6 @@
     "feature_dashed_box": {
       "flow_type": "template",
       "flow_name": "feature_dashed_box",
-      "_xlsxPath": "feature_sheets/to_be_sorted/feature_template_components.xlsx"
-    },
-    "feature_display_group": {
-      "flow_type": "template",
-      "flow_name": "feature_display_group",
       "_xlsxPath": "feature_sheets/to_be_sorted/feature_template_components.xlsx"
     },
     "feature_essential_tools": {

--- a/app_data/sheets/template/component_demo/comp_display_group.json
+++ b/app_data/sheets/template/component_demo/comp_display_group.json
@@ -1,7 +1,8 @@
 {
   "flow_type": "template",
-  "flow_name": "feature_display_group",
+  "flow_name": "comp_display_group",
   "status": "released",
+  "flow_subtype": "component_demo",
   "rows": [
     {
       "type": "display_group",
@@ -143,6 +144,67 @@
         }
       ],
       "_nested_name": "dg_variant_white"
+    },
+    {
+      "type": "display_group",
+      "exclude_from_translation": true,
+      "parameter_list": {
+        "variant": "box_white"
+      },
+      "rows": [
+        {
+          "type": "title",
+          "value": "Variant: box_white",
+          "_translations": {
+            "value": {}
+          },
+          "exclude_from_translation": true,
+          "name": "title_1",
+          "_nested_name": "display_group_14.title_1"
+        }
+      ],
+      "name": "display_group_14",
+      "_nested_name": "display_group_14"
+    },
+    {
+      "type": "display_group",
+      "exclude_from_translation": true,
+      "parameter_list": {
+        "variant": "solid_secondary",
+        "style": "column"
+      },
+      "rows": [
+        {
+          "type": "text",
+          "value": "A TITLE",
+          "_translations": {
+            "value": {}
+          },
+          "exclude_from_translation": true,
+          "style_list": [
+            "font-size: 0.8rem",
+            "color: white"
+          ],
+          "name": "text_1",
+          "_nested_name": "display_group_16.text_1"
+        },
+        {
+          "type": "text",
+          "value": "Variant: solid_secondary",
+          "_translations": {
+            "value": {}
+          },
+          "exclude_from_translation": true,
+          "style_list": [
+            "margin-top: -6px",
+            "color: white"
+          ],
+          "name": "text_2",
+          "_nested_name": "display_group_16.text_2"
+        }
+      ],
+      "name": "display_group_16",
+      "_nested_name": "display_group_16"
     },
     {
       "type": "display_group",
@@ -681,8 +743,8 @@
         "value": {}
       },
       "exclude_from_translation": true,
-      "name": "title_42",
-      "_nested_name": "title_42"
+      "name": "title_46",
+      "_nested_name": "title_46"
     },
     {
       "type": "display_group",
@@ -804,8 +866,8 @@
         "value": {}
       },
       "exclude_from_translation": true,
-      "name": "title_45",
-      "_nested_name": "title_45"
+      "name": "title_49",
+      "_nested_name": "title_49"
     },
     {
       "type": "display_group",
@@ -986,5 +1048,5 @@
       "_nested_name": "dg_bottom_image"
     }
   ],
-  "_xlsxPath": "feature_sheets/to_be_sorted/feature_template_components.xlsx"
+  "_xlsxPath": "component_sheets/component_display_group.xlsx"
 }

--- a/app_data/sheets/template/feature_share.json
+++ b/app_data/sheets/template/feature_share.json
@@ -50,7 +50,7 @@
     },
     {
       "type": "text",
-      "value": "The share action can be called with the following params: `text`, `url`, `file`, `title` and `dialog_title`. These are interpreted differently depending on the app receiving the share data. `dialog_title` will only have an effect on Android.",
+      "value": "The share action can be called with the following params: `text`, `url`, `file`, `title` and `dialog_title`. These are interpreted differently depending on the app receiving the share data. In general, `text`, `file` and `url` seem to be the most widely supported and predictably handled. \n\n`title` and `dialog_title` are exposed for completeness, the latter will only have an effect on Android and seems to be unsupported on more recent Android versions.",
       "_translations": {
         "value": {}
       },

--- a/config.ts
+++ b/config.ts
@@ -14,7 +14,7 @@ config.web.favicon_asset = "images/icons/favicon.svg";
 
 config.git = {
   content_repo: "https://github.com/IDEMSInternational/app-debug-content.git",
-  content_tag_latest: "1.4.5",
+  content_tag_latest: "1.4.6",
 };
 
 config.app_config.ASSET_PACKS = {


### PR DESCRIPTION
Moves the display group demo sheet from [here](https://docs.google.com/spreadsheets/d/1ARbNRGDer5vj9qSpRMZFrMkYifGkH3TLtDVp72YbaqU/edit?gid=1682205958#gid=1682205958) to [here](https://docs.google.com/spreadsheets/d/1IlM2fbVYzVdwPBa9UEaKZhGGlLFhRHCo--T6uC-EQiE/edit?gid=7532536#gid=7532536), adding an explanatory note. Also adds new content to that sheet related to https://github.com/IDEMSInternational/open-app-builder/pull/2773.

I thought it might make sense to highlight this in a dedicated PR just to document the move of the demo sheet: as this demo sheet is one that is likely referenced quite frequently in PRs and issues, it seemed sensible to add a note to original location to redirect to the new one.