### PR TITLE
test: pr-3040 content sync

### DIFF
--- a/app_data/sheets/template/example/example_row_value_transform.json
+++ b/app_data/sheets/template/example/example_row_value_transform.json
@@ -92,7 +92,14 @@
       "name": "example_action_list",
       "value": [
         {
-          "set_local": "button_clicked"
+          "trigger": "click",
+          "action_id": "set_local",
+          "args": [
+            "button_clicked",
+            true
+          ],
+          "_raw": "click | set_local: button_clicked: true",
+          "_cleaned": "click | set_local: button_clicked: true"
         }
       ],
       "type": "set_variable",
@@ -104,52 +111,22 @@
       "_translations": {
         "value": {}
       },
-      "action_list": [
-        {
-          "trigger": "click",
-          "action_id": "@local.example_action_list",
-          "args": [],
-          "_raw": "@local.example_action_list",
-          "_cleaned": "click | @local.example_action_list"
-        }
-      ],
+      "action_list": "@local.example_action_list",
       "name": "button_12",
       "_nested_name": "button_12",
       "_dynamicFields": {
-        "action_list": {
-          "0": {
-            "action_id": [
-              {
-                "fullExpression": "@local.example_action_list",
-                "matchedExpression": "@local.example_action_list",
-                "type": "local",
-                "fieldName": "example_action_list"
-              }
-            ],
-            "_raw": [
-              {
-                "fullExpression": "@local.example_action_list",
-                "matchedExpression": "@local.example_action_list",
-                "type": "local",
-                "fieldName": "example_action_list"
-              }
-            ],
-            "_cleaned": [
-              {
-                "fullExpression": "click | @local.example_action_list",
-                "matchedExpression": "@local.example_action_list",
-                "type": "local",
-                "fieldName": "example_action_list"
-              }
-            ]
+        "action_list": [
+          {
+            "fullExpression": "@local.example_action_list",
+            "matchedExpression": "@local.example_action_list",
+            "type": "local",
+            "fieldName": "example_action_list"
           }
-        }
+        ]
       },
       "_dynamicDependencies": {
         "@local.example_action_list": [
-          "action_list.0.action_id",
-          "action_list.0._raw",
-          "action_list.0._cleaned"
+          "action_list"
         ]
       }
     },

--- a/app_data/sheets/template/feature/feat_notification_actions.json
+++ b/app_data/sheets/template/feature/feat_notification_actions.json
@@ -1251,13 +1251,34 @@
       "name": "example_action_list",
       "value": [
         {
-          "set_field ": "show_notification_bell"
+          "trigger": "click",
+          "action_id": "notification_received",
+          "args": [],
+          "_raw": "notification_received | set_field : show_notification_bell : true",
+          "_cleaned": "click | notification_received | set_field : show_notification_bell : true",
+          "params": {
+            "set_field ": "show_notification_bell"
+          }
         },
         {
-          "set_field ": "show_notification_bell"
+          "trigger": "click",
+          "action_id": "notification_interacted",
+          "args": [],
+          "_raw": "notification_interacted | set_field : show_notification_bell: false",
+          "_cleaned": "click | notification_interacted | set_field : show_notification_bell: false",
+          "params": {
+            "set_field ": "show_notification_bell"
+          }
         },
         {
-          "go_to ": "/user"
+          "trigger": "click",
+          "action_id": "notification_interacted",
+          "args": [],
+          "_raw": "notification_interacted | go_to : /user",
+          "_cleaned": "click | notification_interacted | go_to : /user",
+          "params": {
+            "go_to ": "/user"
+          }
         }
       ],
       "type": "set_variable",

--- a/app_data/sheets/template/feature_parent_point_box.json
+++ b/app_data/sheets/template/feature_parent_point_box.json
@@ -140,10 +140,18 @@
     },
     {
       "name": "icon_button_action_list",
-      "value": "click | set_field : something : dsfsd",
-      "_translations": {
-        "value": {}
-      },
+      "value": [
+        {
+          "trigger": "click",
+          "action_id": "set_field",
+          "args": [
+            "something",
+            "dsfsd"
+          ],
+          "_raw": "click | set_field : something : dsfsd",
+          "_cleaned": "click | set_field : something : dsfsd"
+        }
+      ],
       "type": "set_variable",
       "_nested_name": "icon_button_action_list"
     },

--- a/reports/summary.json
+++ b/reports/summary.json
@@ -318,10 +318,6 @@
   "template_actions": {
     "data": [
       {
-        "type": "@local.example_action_list",
-        "count": 1
-      },
-      {
         "type": "add_data",
         "count": 2
       },
@@ -523,7 +519,7 @@
       },
       {
         "type": "undefined",
-        "count": 17
+        "count": 43
       },
       {
         "type": "user",

--- a/reports/summary.md
+++ b/reports/summary.md
@@ -88,7 +88,6 @@
 
 | type | count |
 | --- | --- |
-| @local.example_action_list | 1 |
 | add_data | 2 |
 | app_update | 3 |
 | asset_pack | 2 |
@@ -139,7 +138,7 @@
 | toggle_field | 4 |
 | track_event | 2 |
 | trigger_actions | 1 |
-| undefined | 17 |
+| undefined | 43 |
 | user | 2 |
 </details>
 


### PR DESCRIPTION
Targetting `master` branch as content just updated

Should see diff to 3 files:

**app_data/sheets/template/example/example_row_value_transform.json**
As expected to correctly parse inline action lists

**app_data/sheets/template/feature/feat_notification_actions.json**
As expected to correctly parse inline action list (but still incorrect syntax as required notification action triggers from follow-up pr

**app_data/sheets/template/feature_parent_point_box.json**
Potential breaking change identified to parent_point_box which handles actions in custom way

https://github.com/IDEMSInternational/open-app-builder/pull/3040